### PR TITLE
Add `allow-unresolved-version` go-proxy config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,10 @@ The `version.want` option allows a special entry:
 
 The `go-proxy` version method reaches out to `proxy.golang.org` to determine the latest version of a Go module. It requires the following configuration options:
 
-| Option | Description                                                                                      |
-|--------|--------------------------------------------------------------------------------------------------|
-| `module` | The FQDN to the Go module (e.g. `github.com/anchore/syft`)                  |
+| Option | Description                                                                                                          |
+|--------|----------------------------------------------------------------------------------------------------------------------|
+| `module` | The FQDN to the Go module (e.g. `github.com/anchore/syft`)                                                           |
+| `allow-unresolved-version` | If the latest version cannot be found by the proxy allow for "latest" as a valid value (which `go install` supports) | 
 
 The `version.want` option allows a special entry:
 - `latest`: don't pin to a version, use the latest available

--- a/tool/goproxy/version_resolver_test.go
+++ b/tool/goproxy/version_resolver_test.go
@@ -44,6 +44,29 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			version: "bogus",
 			want:    "bogus",
 		},
+		{
+			name: "do not allow for unresolved versions",
+			config: VersionResolutionParameters{
+				Module: "github.com/anchore/binny",
+			},
+			version: "latest",
+			wantErr: require.Error,
+			availableVersionsFetcher: func(url string) ([]string, error) {
+				return []string{""}, nil
+			},
+		},
+		{
+			name: "allow for unresolved versions",
+			config: VersionResolutionParameters{
+				Module:                 "github.com/anchore/binny",
+				AllowUnresolvedVersion: true,
+			},
+			version: "latest",
+			want:    "latest", // this is a pass through to go-install, which supports this as input
+			availableVersionsFetcher: func(url string) ([]string, error) {
+				return []string{""}, nil
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
In case a go module does not have any tags (such as https://cs.opensource.google/go/x/perf) then allow for version resolution logic to provide `latest` as a valid resolved value.

Ideally in the future this would fall back to a remote `git` version resolver and select a commit, however, this is also a good (and easier) option in the mean time. The downside with this current approach is that the version value cannot be used to detect staleness of the installation.