### PR TITLE
Ensure unresolved go-proxy version does not check online

### DIFF
--- a/tool/goproxy/version_resolver.go
+++ b/tool/goproxy/version_resolver.go
@@ -38,7 +38,7 @@ func (v VersionResolver) ResolveVersion(want, _ string) (string, error) {
 		return want, nil
 	}
 
-	if want == latest {
+	if want == latest && !v.config.AllowUnresolvedVersion {
 		return v.findLatestVersion("")
 	}
 

--- a/tool/goproxy/version_resolver_test.go
+++ b/tool/goproxy/version_resolver_test.go
@@ -1,6 +1,7 @@
 package goproxy
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,7 +65,7 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			version: "latest",
 			want:    "latest", // this is a pass through to go-install, which supports this as input
 			availableVersionsFetcher: func(url string) ([]string, error) {
-				return []string{""}, nil
+				return nil, fmt.Errorf("should never be called")
 			},
 		},
 	}


### PR DESCRIPTION
#8  added the ability to keep `latest` as an unresolved version. This PR fixes the behavior where `latest` does not automatically mean that an online check will be done to find the latest version.