### PR TITLE
Add update filter to list command

### DIFF
--- a/cmd/binny/cli/option/list.go
+++ b/cmd/binny/cli/option/list.go
@@ -1,0 +1,11 @@
+package option
+
+import "github.com/anchore/clio"
+
+type List struct {
+	Updates bool `json:"updates" yaml:"updates" mapstructure:"updates"`
+}
+
+func (o *List) AddFlags(flags clio.FlagSet) {
+	flags.BoolVarP(&o.Updates, "updates", "", "List only tool installations that need to be updated (relative to what is currently installed)")
+}


### PR DESCRIPTION
Can list out only the updates needed based on the configured version and the installed version:
```
$ binny list --updates
 TOOL        UPDATE            
───────────────────────────────
 binny       0ccc593 → e2f8a97 
 gh          v2.36.0 → v2.35.0 
 goreleaser  v1.21.2 → v1.21.1 
 syft        v0.92.0 → v0.91.0
```

Compared with the vanilla list command:
```
$ binny list
 TOOL           DESIRED VERSION                                                                          
─────────────────────────────────────────────────────────────────────────────────────────────────────────
 benchstat      ?                  tool is not configured                                                
 binny          current (e2f8a97)  installed version (0ccc593) does not match resolved version (e2f8a97) 
 bouncer        v0.4.0                                                                                   
 chronicle      v0.8.0                                                                                   
 gh             v2.35.0            installed version (v2.36.0) does not match resolved version (v2.35.0) 
 glow           v1.5.1                                                                                   
 golangci-lint  v1.54.2                                                                                  
 goreleaser     v1.21.1            installed version (v1.21.2) does not match resolved version (v1.21.1) 
 gosimports     v0.3.8                                                                                   
 quill          v0.4.1                                                                                   
 syft           v0.91.0            installed version (v0.92.0) does not match resolved version (v0.91.0) 
 task           v3.30.1  
```