### PR TITLE
Add multiple strategies for querying GitHub release and assets info

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -24,9 +24,6 @@ jobs:
 
       - name: Bootstrap environment
         uses: ./.github/actions/bootstrap
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FORCE_COLOR: true
 
       - name: Run all validations
         run: make pr-validations

--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ The `github-release` version method uses the GitHub Releases API to determine th
 The `version.want` option allows a special entry:
 - `latest`: don't pin to a version, use the latest available
 
+Note: this approach will might require a GitHub API token to be set in the `GITHUB_TOKEN` environment variable if there
+is a version constraint used.
+
 #### `go-proxy`
 
 The `go-proxy` version method reaches out to `proxy.golang.org` to determine the latest version of a Go module. It requires the following configuration options:

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.2
 	github.com/gkampitakis/go-snaps v0.4.10
 	github.com/go-git/go-git/v5 v5.9.0
+	github.com/google/go-cmp v0.5.9
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/yamlfmt v0.9.1-0.20230607021126-908b19015fc4
 	github.com/hashicorp/go-multierror v1.1.1
@@ -31,6 +32,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/wagoodman/go-partybus v0.0.0-20230516145632-8ccac152c651
 	github.com/wagoodman/go-progress v0.0.0-20230911172108-cf810b7e365c
+	golang.org/x/net v0.15.0
 	golang.org/x/oauth2 v0.8.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/term v0.12.0
@@ -70,7 +72,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/gookit/color v1.5.4 // indirect
@@ -132,7 +133,6 @@ require (
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
 	golang.org/x/crypto v0.13.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
-	golang.org/x/net v0.15.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect

--- a/internal/download_file.go
+++ b/internal/download_file.go
@@ -1,47 +1,101 @@
 package internal
 
 import (
+	"crypto/md5"  // nolint:gosec // MD5 is used for legacy compatibility
+	"crypto/sha1" // nolint:gosec // SHA1 is used for legacy compatibility
 	"crypto/sha256"
+	"crypto/sha512"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
-	"github.com/anchore/binny/internal/log"
+	"github.com/go-git/go-git/v5/plumbing/hash"
+
+	"github.com/anchore/go-logger"
 )
 
-func DownloadFile(url string, filepath string, checksum string) (err error) {
+func DownloadFile(lgr logger.Logger, url string, filepath string, checksum string) (err error) {
+	reader, err := DownloadURL(lgr, url)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
 	out, err := os.Create(filepath)
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 
-	resp, err := http.Get(url) // nolint:gosec
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("bad status: %s", resp.Status)
-	}
-
-	// take sha256 of file and compare with checksum while copying to disk
-	h := sha256.New()
-	tee := io.TeeReader(resp.Body, h)
+	// hash the file and compare with checksum while copying to disk
+	h := getHasher(checksum)
+	tee := io.TeeReader(reader, h)
 
 	if _, err := io.Copy(out, tee); err != nil {
 		return err
 	}
 
 	if checksum != "" {
-		if checksum != fmt.Sprintf("%x", h.Sum(nil)) {
+		expectedChecksum := cleanChecksum(checksum)
+		actualChecksum := fmt.Sprintf("%x", h.Sum(nil))
+
+		if expectedChecksum != actualChecksum {
+			lgr.WithFields("url", url, "expected", expectedChecksum, "actual", actualChecksum).Warn("checksum mismatch")
 			return fmt.Errorf("checksum mismatch for %q", filepath)
 		}
 
-		log.WithFields("checksum", checksum, "asset", filepath, "url", url).Trace("checksum verified")
+		lgr.WithFields("checksum", expectedChecksum, "asset", filepath, "url", url).Trace("checksum verified")
 	}
 
 	return nil
+}
+
+func DownloadURL(lgr logger.Logger, url string) (io.ReadCloser, error) {
+	resp, err := http.Get(url) // nolint: gosec  // we must be able to get arbitrary URLs
+	if err != nil {
+		return nil, fmt.Errorf("unable to download %q: %w", url, err)
+	}
+
+	lgr.WithFields("http-status", resp.StatusCode).Tracef("http get %q", url)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil
+	}
+	return resp.Body, nil
+}
+
+func cleanChecksum(checksum string) string {
+	parts := strings.SplitN(checksum, ":", 2)
+	if len(parts) < 2 {
+		return checksum
+	}
+
+	return parts[1]
+}
+
+func getHasher(checksum string) hash.Hash {
+	// Default to SHA-256 if no prefix or unsupported prefix
+	defaultHash := sha256.New()
+
+	parts := strings.SplitN(checksum, ":", 2)
+	if len(parts) < 2 {
+		return defaultHash
+	}
+
+	algorithm := strings.ToLower(parts[0])
+
+	switch algorithm {
+	case "sha256":
+		return sha256.New()
+	case "sha1":
+		return sha1.New() // nolint:gosec // SHA1 is used for legacy compatibility
+	case "sha512":
+		return sha512.New()
+	case "md5":
+		return md5.New() // nolint:gosec // MD5 is used for legacy compatibility
+	default:
+		return defaultHash
+	}
 }

--- a/internal/download_file_test.go
+++ b/internal/download_file_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/go-logger/adapter/discard"
 )
 
 func Test_DownloadFile(t *testing.T) {
@@ -49,7 +51,7 @@ func Test_DownloadFile(t *testing.T) {
 			dir := t.TempDir()
 			dlPath := filepath.Join(dir, "the-file-path.txt")
 
-			tt.wantErr(t, DownloadFile(s.URL, dlPath, tt.checksum))
+			tt.wantErr(t, DownloadFile(discard.New(), s.URL, dlPath, tt.checksum))
 
 			gotContents, err := os.ReadFile(dlPath)
 			require.NoError(t, err)

--- a/store.go
+++ b/store.go
@@ -257,7 +257,7 @@ func (s Store) saveState() error {
 func (e *StoreEntry) Verify(useXxh64, useSha256 bool) error {
 	// at least the file must exist
 	if _, err := os.Stat(e.Path()); err != nil {
-		return fmt.Errorf("failed to validate tool %q: %w", e.Name, err)
+		return err
 	}
 
 	if useXxh64 {

--- a/tool/githubrelease/gh_release.go
+++ b/tool/githubrelease/gh_release.go
@@ -1,0 +1,48 @@
+package githubrelease
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ghRelease struct {
+	Tag      string
+	Date     *time.Time
+	IsLatest *bool
+	IsDraft  *bool
+	Assets   []ghAsset
+}
+
+type ghAsset struct {
+	Name        string
+	ContentType string
+	URL         string
+	Checksum    string
+}
+
+func (a *ghAsset) addChecksum(value string) {
+	if strings.Contains(value, ":") {
+		a.Checksum = value
+		return
+	}
+
+	// note: assume this is a hex digest
+	var method string
+	switch len(value) {
+	case 32:
+		method = "md5"
+	case 40:
+		method = "sha1"
+	case 64:
+		method = "sha256"
+	case 128:
+		method = "sha512"
+	default:
+		// dunno, just capture the value
+		a.Checksum = value
+		return
+	}
+
+	a.Checksum = fmt.Sprintf("%s:%s", method, value)
+}

--- a/tool/githubrelease/installer.go
+++ b/tool/githubrelease/installer.go
@@ -4,21 +4,25 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/mholt/archiver/v3"
 	"github.com/scylladb/go-set/strset"
 	"github.com/shurcooL/githubv4"
+	"golang.org/x/net/html"
 	"golang.org/x/oauth2"
 
 	"github.com/anchore/binny"
 	"github.com/anchore/binny/internal"
 	"github.com/anchore/binny/internal/log"
+	"github.com/anchore/go-logger"
 )
 
 const checksumsFilename = "checksums.txt"
@@ -87,7 +91,7 @@ type InstallerParameters struct {
 
 type Installer struct {
 	config         InstallerParameters
-	releaseFetcher func(user, repo, tag string) (*ghRelease, error)
+	releaseFetcher func(lgr logger.Logger, user, repo, tag string) (*ghRelease, error)
 }
 
 func NewInstaller(cfg InstallerParameters) Installer {
@@ -98,7 +102,9 @@ func NewInstaller(cfg InstallerParameters) Installer {
 }
 
 func (i Installer) InstallTo(version, destDir string) (string, error) {
-	log.WithFields("repo", i.config.Repo, "version", version).Debug("installing from github release assets")
+	lgr := log.Nested("tool", fmt.Sprintf("%s@%s", i.config.Repo, version))
+
+	lgr.Debug("installing from github release assets")
 
 	fields := strings.Split(i.config.Repo, "/")
 	if len(fields) != 2 {
@@ -106,19 +112,19 @@ func (i Installer) InstallTo(version, destDir string) (string, error) {
 	}
 	user, repo := fields[0], fields[1]
 
-	release, err := i.releaseFetcher(user, repo, version)
+	release, err := i.releaseFetcher(lgr, user, repo, version)
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch github release %s@%s: %w", i.config.Repo, version, err)
 	}
 
-	asset := selectBinaryAsset(release.Assets, runtime.GOOS, runtime.GOARCH)
+	asset := selectBinaryAsset(lgr, release.Assets, runtime.GOOS, runtime.GOARCH)
 	if asset == nil {
 		return "", fmt.Errorf("unable to find matching asset for %s@%s", i.config.Repo, version)
 	}
 
-	checksumAsset := selectChecksumAsset(release.Assets)
+	checksumAsset := selectChecksumAsset(lgr, release.Assets)
 
-	binPath, err := downloadAndExtractAsset(*asset, checksumAsset, destDir)
+	binPath, err := downloadAndExtractAsset(lgr, *asset, checksumAsset, destDir)
 	if err != nil {
 		return "", fmt.Errorf("unable to download and extract asset %s@%s: %w", i.config.Repo, version, err)
 	}
@@ -126,18 +132,16 @@ func (i Installer) InstallTo(version, destDir string) (string, error) {
 	return binPath, nil
 }
 
-func downloadAndExtractAsset(asset ghAsset, checksumAsset *ghAsset, destDir string) (string, error) {
+func downloadAndExtractAsset(lgr logger.Logger, asset ghAsset, checksumAsset *ghAsset, destDir string) (string, error) {
 	assetPath := path.Join(destDir, asset.Name)
 
-	log.WithFields("destination", assetPath).Trace("downloading asset")
-
-	var checksum string
-	if checksumAsset != nil {
-		log.WithFields("asset", checksumAsset.Name).Trace("downloading checksum manifest")
+	checksum := asset.Checksum
+	if checksumAsset != nil && checksum == "" {
+		lgr.WithFields("asset", checksumAsset.Name).Trace("downloading checksum manifest")
 
 		checksumsPath := path.Join(destDir, checksumsFilename)
 
-		if err := internal.DownloadFile(checksumAsset.URL, checksumsPath, ""); err != nil {
+		if err := internal.DownloadFile(lgr, checksumAsset.URL, checksumsPath, ""); err != nil {
 			return "", fmt.Errorf("unable to download checksum asset %q: %w", checksumAsset.Name, err)
 		}
 
@@ -148,7 +152,17 @@ func downloadAndExtractAsset(asset ghAsset, checksumAsset *ghAsset, destDir stri
 		}
 	}
 
-	if err := internal.DownloadFile(asset.URL, assetPath, checksum); err != nil {
+	logFields := logger.Fields{
+		"destination": assetPath,
+	}
+
+	if checksum != "" {
+		logFields["checksum"] = checksum
+	}
+
+	lgr.WithFields(logFields).Trace("downloading asset")
+
+	if err := internal.DownloadFile(lgr, asset.URL, assetPath, checksum); err != nil {
 		return "", fmt.Errorf("unable to download asset %q: %w", asset.Name, err)
 	}
 
@@ -158,18 +172,27 @@ func downloadAndExtractAsset(asset ghAsset, checksumAsset *ghAsset, destDir stri
 		return "", fmt.Errorf("asset %q does not exist", assetPath)
 	}
 
-	log.WithFields("size", v.Size(), "asset", asset.Name).Trace("downloaded asset")
+	lgr.WithFields("size", v.Size(), "asset", asset.Name).Trace("downloaded asset")
 
 	switch {
-	case archiveMimeTypes.Has(asset.ContentType):
-		log.WithFields("asset", asset.Name).Trace("asset is an archive")
+	case archiveMimeTypes.Has(asset.ContentType) || (asset.ContentType == "" && hasArchiveExtension(asset.Name)):
+		lgr.WithFields("asset", asset.Name).Trace("asset is an archive")
 		return extractArchive(assetPath, destDir)
-	case binaryMimeTypes.Has(asset.ContentType):
-		log.WithFields("asset", asset.Name).Trace("asset is a binary")
+	case binaryMimeTypes.Has(asset.ContentType) || (asset.ContentType == "" && hasBinaryExtension(asset.Name)):
+		lgr.WithFields("asset", asset.Name).Trace("asset is a binary")
 		return assetPath, nil
 	}
 
 	return "", fmt.Errorf("unsupported asset content-type: %q", asset.ContentType)
+}
+
+func hasArchiveExtension(name string) bool {
+	ext := path.Ext(name)
+	switch ext {
+	case ".tar", ".zip", ".gz", ".bz2", ".xz", ".rar", ".7z", ".tar.gz", ".tgz", ".tar.bz", ".tbz", ".tar.zst", ".zst":
+		return true
+	}
+	return false
 }
 
 func getChecksumForAsset(assetName, checksumsPath string) (string, error) {
@@ -283,16 +306,18 @@ func mimeTypeOfFile(p string) (string, error) {
 	return strings.Split(mimeType.String(), ";")[0], nil
 }
 
-func selectChecksumAsset(assets []ghAsset) *ghAsset {
+func selectChecksumAsset(lgr logger.Logger, assets []ghAsset) *ghAsset {
 	// search for the asset by name with the OS and arch in the name
 	// e.g. chronicle_0.7.0_checksums.txt
 
+	lgr.Trace("looking for checksum artifact")
+
 	for _, asset := range assets {
 		switch strings.Split(asset.ContentType, ";")[0] {
-		case "text/plain":
+		case "text/plain", "":
 			// pass
 		default:
-			log.WithFields("asset", asset.Name).Tracef("skipping asset (content type %q can't be a checksum)", asset.ContentType)
+			lgr.WithFields("asset", asset.Name).Tracef("skipping asset (content type %q can't be a checksum)", asset.ContentType)
 
 			continue
 		}
@@ -300,7 +325,7 @@ func selectChecksumAsset(assets []ghAsset) *ghAsset {
 		lowerName := strings.ToLower(asset.Name)
 
 		if !strings.HasSuffix(lowerName, checksumsFilename) {
-			log.WithFields("asset", asset.Name).Trace("skipping asset (name does not indicate checksums)")
+			lgr.WithFields("asset", asset.Name).Trace("skipping asset (name does not indicate checksums)")
 			continue
 		}
 		return &asset
@@ -358,7 +383,7 @@ var osAliases = map[string][]string{
 	"zos":       {},
 }
 
-func selectBinaryAsset(assets []ghAsset, goOS, goArch string) *ghAsset {
+func selectBinaryAsset(lgr logger.Logger, assets []ghAsset, goOS, goArch string) *ghAsset {
 	// search for the asset by name with the OS and arch in the name
 	// e.g. chronicle_0.7.0_linux_amd64.tar.gz
 
@@ -369,38 +394,55 @@ func selectBinaryAsset(assets []ghAsset, goOS, goArch string) *ghAsset {
 	isHostDarwin := strset.New(allOSs("darwin")...).Has(goos)
 	universalDarwinArchSuffix := asSuffix([]string{"universal", "all"})
 
+	lgr.Trace("looking for binary artifact")
+
 	for _, asset := range assets {
-		switch {
-		case archiveMimeTypes.Has(asset.ContentType):
+		cleanName := strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(asset.Name), ".", "_"), "-", "_")
+
+		if !containsOneOf(cleanName, asSuffix(gooss)) {
+			lgr.WithFields("asset", asset.Name).Tracef("skipping asset (missing os %q)", gooss)
+			continue
+		}
+
+		if isHostDarwin && containsOneOf(cleanName, universalDarwinArchSuffix) {
+			lgr.WithFields("asset", asset.Name).Trace("found asset (universal binary)")
 			// pass
-		case binaryMimeTypes.Has(asset.ContentType):
+		} else if !containsOneOf(cleanName, goarchs) {
+			lgr.WithFields("asset", asset.Name).Tracef("skipping asset (missing arch %q)", goarchs)
+			continue
+		}
+
+		// we only want to look at a section that doesn't have the version (with periods in it) but will have the
+		// extension (e.g. .tar.gz). If there is no extension, the odds of there being a version is still slim.
+		suffixWithExtension := asset.Name
+		if len(asset.Name) > 9 {
+			suffixWithExtension = asset.Name[len(asset.Name)-9:]
+		}
+
+		switch {
+		case archiveMimeTypes.Has(asset.ContentType) || (asset.ContentType == "" && hasArchiveExtension(suffixWithExtension)):
+			// pass
+		case binaryMimeTypes.Has(asset.ContentType) || (asset.ContentType == "" && hasBinaryExtension(suffixWithExtension)):
 			// pass
 		default:
-			log.WithFields("asset", asset.Name).Tracef("skipping asset (content type %q)", asset.ContentType)
+			lgr.WithFields("asset", asset.Name).Tracef("skipping asset (content type %q)", asset.ContentType)
 
 			continue
 		}
 
-		lowerName := strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(asset.Name), ".", "_"), "-", "_")
-
-		if !containsOneOf(lowerName, asSuffix(gooss)) {
-			log.WithFields("asset", asset.Name).Tracef("skipping asset (missing os %q)", gooss)
-			continue
-		}
-
-		// look for universal binaries for darwin
-		if isHostDarwin && containsOneOf(lowerName, universalDarwinArchSuffix) {
-			log.WithFields("asset", asset.Name).Trace("found asset (universal binary)")
-			return &asset
-		} else if !containsOneOf(lowerName, goarchs) {
-			log.WithFields("asset", asset.Name).Tracef("skipping asset (missing arch %q)", goarchs)
-			continue
-		}
-
-		log.WithFields("asset", asset.Name).Trace("found asset")
+		lgr.WithFields("asset", asset.Name).Trace("found asset")
 		return &asset
 	}
 	return nil
+}
+
+func hasBinaryExtension(name string) bool {
+	ext := path.Ext(name)
+	switch ext {
+	case ".exe", "":
+		return true
+	}
+	return false
 }
 
 func allArchs(key string) []string {
@@ -436,11 +478,234 @@ func containsOneOf(subject string, needles []string) bool {
 	return false
 }
 
+func fetchRelease(lgr logger.Logger, user, repo, tag string) (r *ghRelease, err error) {
+	summary := fmt.Sprintf("%s/%s@%s", user, repo, tag)
+
+	lgr.Trace("fetching release info")
+
+	defer func() {
+		if r == nil {
+			lgr.Tracef("no release found")
+			return
+		}
+
+		lgr.Tracef("release found with %d release assets", len(r.Assets))
+	}()
+
+	r, err = fetchReleaseByScrape(lgr, user, repo, tag)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch release %s via scrape: %w", summary, err)
+	}
+
+	if r != nil {
+		return r, nil
+	}
+
+	lgr.Trace("unable to fetch release via scrape, trying checksums...")
+
+	// why try this second instead of first? there are multiple reasons:
+	// - there are multiple places to look for checksums
+	// - there is no guarantee they even exist!
+	r, err = fetchReleaseByChecksums(lgr, user, repo, tag)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch release %s via checksums: %w", summary, err)
+	}
+
+	if r != nil {
+		return r, nil
+	}
+
+	lgr.Trace("unable to fetch release via checksums, trying GitHub v4 API...")
+
+	// note: I would remove this approach, however, it is the most kosher way to get this information so I'm leaving it in for now.
+	// It is quite unfortunate that either auth is required (v4) or there is extreme rate limiting (v3).
+	r, err = fetchReleaseGithubV4API(user, repo, tag)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch release %s via GitHub v4 API: %w", summary, err)
+	}
+
+	return r, nil
+}
+
+func fetchReleaseByChecksums(lgr logger.Logger, user, repo, tag string) (*ghRelease, error) {
+	// look for a {checksums.txt, repo_tag_checksums.txt, repo_tag-without-v_checksums.txt} file in the release assets
+	// if found, download it and parse it to find the asset we want
+	// e.g.
+	// - https://github.com/anchore/syft/releases/download/v0.93.0/syft_0.93.0_checksums.txt (underscores)
+	// - https://github.com/golangci/golangci-lint/releases/download/v1.54.2/golangci-lint-1.54.2-checksums.txt  (dashes)
+	// - https://github.com/charmbracelet/glow/releases/download/v1.5.1/checksums.txt (no repo/version)
+
+	for _, url := range checksumURLVariants(user, repo, tag) {
+		lgr.WithFields("url", url).Trace("trying checksums url")
+		reader, err := internal.DownloadURL(lgr, url)
+		if err != nil {
+			return nil, err
+		}
+
+		release := handleChecksumsReader(lgr, user, repo, tag, url, reader)
+		if release == nil {
+			continue
+		}
+
+		return release, nil
+	}
+
+	return nil, nil
+}
+
+func checksumURLVariants(user, repo, tag string) []string {
+	dlURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s", user, repo, tag)
+
+	tagWithoutPrefixV := strings.TrimPrefix(tag, "v")
+
+	variants := strset.New(
+		"checksums.txt",
+		fmt.Sprintf("%s_%s_checksums.txt", repo, tagWithoutPrefixV),
+		fmt.Sprintf("%s_%s_checksums.txt", repo, tag),
+		fmt.Sprintf("%s-%s-checksums.txt", repo, tagWithoutPrefixV),
+		fmt.Sprintf("%s-%s-checksums.txt", repo, tag),
+	)
+
+	variantsList := variants.List()
+	sort.Strings(variantsList)
+
+	var urls []string
+	for _, variant := range variantsList {
+		urls = append(urls, fmt.Sprintf("%s/%s", dlURL, variant))
+	}
+
+	return urls
+}
+
+func handleChecksumsReader(lgr logger.Logger, user, repo, tag, url string, reader io.ReadCloser) *ghRelease {
+	if reader == nil {
+		return nil
+	}
+	defer reader.Close()
+
+	// parse output like this to create asset entries:
+	//
+	// 10ca05f5cfbac1b2c24a4a28b1f2a7446409769a74cc8a079a5c63bc2fbfb6e1  syft_0.93.0_linux_amd64.rpm
+	// 169da07ce4cbe5f59ae3cc6a65b7b7b539ed07b987905e526d5fc4491ea0024e  syft_0.93.0_darwin_arm64.tar.gz
+	// 193ff3ed631b5d5acbef575885a3417883c371f713bfead677a167f6ebe7603c  syft_0.93.0_linux_s390x.tar.gz
+	// 1c1e3da7cec98e54720832a43fa1bed4e893e63a6be267d5ec55d62418535d2f  syft_0.93.0_linux_ppc64le.deb
+	// 2ebf4167cbd499eb39119023d5f2e69b75af2223aea73115c5fc03e8a6e9e0c0  syft_0.93.0_linux_amd64.deb
+	// 334bd4f1b41ef21f675bdb7113d32076377da6cced741c3365f76bdb7120ddac  syft_0.93.0_linux_arm64.rpm
+	// 5fb0eb70c0f618e9a8b93d68b59da4b5758164b1aacc062e2150341baf7acc73  syft_0.93.0_linux_amd64.tar.gz
+	// 64b31c2a078ac05889aa1f365afa8aa63f847b1750036cab19bba11a054e5fe3  syft_0.93.0_linux_ppc64le.tar.gz
+	// 78da6446129fa3ae65114ddf8a56b7d581e21796fd7db8c0724d9ae8f8e3eeb4  syft_0.93.0_windows_amd64.zip
+	// a40c32ecb52da7d9d7adf42f9321f73f179373d461685b168b0904d27cabed39  syft_0.93.0_linux_arm64.deb
+	// b3b438990b043a0fe6f1b993ac3b88a2e0d7c2d98650156ec568b4754214662d  syft_0.93.0_linux_s390x.deb
+	// b413c6b10815f2512a2f44b9a554521c376759e91ac411b157b6b44937e652a8  syft_0.93.0_linux_s390x.rpm
+	// f2f8889305350ee3a53a012246acfa10b59b7aee67e9b6a2e811f05b67f74588  syft_0.93.0_linux_arm64.tar.gz
+	// fbf8d99ff614221bdb78dc608dd4430b0fd04a56939a779818c7b296dfd470f1  syft_0.93.0_darwin_amd64.tar.gz
+	// ff289b81c0f2bec792f2125ef0f3d7b78e70684b9fd4dcb3037f32c0c53b9328  syft_0.93.0_linux_ppc64le.rpm
+
+	release := &ghRelease{
+		Tag: tag,
+	}
+
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if len(line) == 0 {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			lgr.WithFields("url", url).Trace("invalid checksums line: %q", line)
+			return nil
+		}
+		name := fields[1]
+		checksum := fields[0]
+		asset := ghAsset{
+			Name:        name,
+			ContentType: "",
+			URL:         fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s", user, repo, tag, name),
+		}
+		asset.addChecksum(checksum)
+
+		release.Assets = append(release.Assets, asset)
+	}
+
+	if len(release.Assets) == 0 {
+		return nil
+	}
+
+	return release
+}
+
+func fetchReleaseByScrape(lgr logger.Logger, user, repo, tag string) (*ghRelease, error) {
+	// fetch assets list via the expanded assets view endpoint used by the GitHub UI
+	// note: this is quite brittle, super grain of salt here...
+	// e.g. https://github.com/anchore/syft/releases/expanded_assets/v0.93.0
+	// which will have href values like "/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_amd64.deb"
+
+	url := fmt.Sprintf("https://github.com/%s/%s/releases/expanded_assets/%s", user, repo, tag)
+
+	reader, err := internal.DownloadURL(lgr, url)
+	if err != nil {
+		return nil, err
+	}
+
+	if reader == nil {
+		return nil, nil
+	}
+
+	defer reader.Close()
+
+	return &ghRelease{
+		Tag:    tag,
+		Assets: processExpandedAssets(lgr, reader, url),
+	}, nil
+}
+
+func processExpandedAssets(lgr logger.Logger, reader io.Reader, from string) []ghAsset {
+	tokenizer := html.NewTokenizer(reader)
+
+	var assets []ghAsset
+
+	for {
+		tokenType := tokenizer.Next()
+
+		if tokenType == html.ErrorToken {
+			err := tokenizer.Err()
+			if err == io.EOF {
+				break
+			}
+
+			lgr.WithFields("error", tokenizer.Err()).Trace("error tokenizing html from %q", from)
+		}
+
+		switch tokenType {
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := tokenizer.Token()
+			if token.Data == "a" {
+				for _, attr := range token.Attr {
+					if attr.Key == "href" && strings.Contains(attr.Val, "/releases/download/") {
+						assets = append(assets, ghAsset{
+							Name:        path.Base(attr.Val),
+							ContentType: "",
+							URL:         fmt.Sprintf("https://github.com%s", attr.Val),
+						})
+					}
+				}
+			}
+		}
+	}
+	return assets
+}
+
 // nolint:funlen
-func fetchRelease(user, repo, tag string) (*ghRelease, error) {
+func fetchReleaseGithubV4API(user, repo, tag string) (*ghRelease, error) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return nil, fmt.Errorf("GITHUB_TOKEN environment variable not set but is required to use the GitHub v4 API")
+	}
 	src := oauth2.StaticTokenSource(
 		// TODO: DI this
-		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
+		&oauth2.Token{AccessToken: token},
 	)
 	httpClient := oauth2.NewClient(context.Background(), src)
 	client := githubv4.NewClient(httpClient)
@@ -513,9 +778,9 @@ func fetchRelease(user, repo, tag string) (*ghRelease, error) {
 
 	return &ghRelease{
 		Tag:      string(query.Repository.Release.TagName),
-		IsLatest: bool(query.Repository.Release.IsLatest),
-		IsDraft:  bool(query.Repository.Release.IsDraft),
-		Date:     query.Repository.Release.PublishedAt.Time,
+		IsLatest: boolRef(bool(query.Repository.Release.IsLatest)),
+		IsDraft:  boolRef(bool(query.Repository.Release.IsDraft)),
+		Date:     &query.Repository.Release.PublishedAt.Time,
 		Assets:   assets,
 	}, nil
 }

--- a/tool/githubrelease/testdata/expandedAssets.html
+++ b/tool/githubrelease/testdata/expandedAssets.html
@@ -1,0 +1,202 @@
+<div data-view-component="true" class="Box Box--condensed mt-3">
+  
+  
+    <ul data-view-component="true">
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_checksums.txt" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_checksums.txt</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">1.4 KB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:29Z" class="no-wrap" prefix="">2023-10-10T17:38:29Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_darwin_amd64.tar.gz" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_darwin_amd64.tar.gz</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">15.4 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:22Z" class="no-wrap" prefix="">2023-10-10T17:38:22Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_darwin_arm64.tar.gz" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_darwin_arm64.tar.gz</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">14.7 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:22Z" class="no-wrap" prefix="">2023-10-10T17:38:22Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_amd64.deb" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_amd64.deb</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">14.6 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:27Z" class="no-wrap" prefix="">2023-10-10T17:38:27Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_amd64.rpm" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_amd64.rpm</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">15.1 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:25Z" class="no-wrap" prefix="">2023-10-10T17:38:25Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_amd64.tar.gz" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_amd64.tar.gz</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">14.6 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:20Z" class="no-wrap" prefix="">2023-10-10T17:38:20Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_arm64.deb" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_arm64.deb</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">13.6 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:26Z" class="no-wrap" prefix="">2023-10-10T17:38:26Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_arm64.rpm" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_arm64.rpm</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">14 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:24Z" class="no-wrap" prefix="">2023-10-10T17:38:24Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_arm64.tar.gz" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_arm64.tar.gz</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">13.6 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:20Z" class="no-wrap" prefix="">2023-10-10T17:38:20Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_ppc64le.deb" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_ppc64le.deb</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">13.4 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:27Z" class="no-wrap" prefix="">2023-10-10T17:38:27Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_ppc64le.rpm" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_ppc64le.rpm</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">13.9 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:25Z" class="no-wrap" prefix="">2023-10-10T17:38:25Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_ppc64le.tar.gz" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_ppc64le.tar.gz</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">13.4 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:21Z" class="no-wrap" prefix="">2023-10-10T17:38:21Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_s390x.deb" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_s390x.deb</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">14.2 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:28Z" class="no-wrap" prefix="">2023-10-10T17:38:28Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_s390x.rpm" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_s390x.rpm</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">14.9 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:26Z" class="no-wrap" prefix="">2023-10-10T17:38:26Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_linux_s390x.tar.gz" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_linux_s390x.tar.gz</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">14.2 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:21Z" class="no-wrap" prefix="">2023-10-10T17:38:21Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package color-fg-muted">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+        <a href="/anchore/syft/releases/download/v0.93.0/syft_0.93.0_windows_amd64.zip" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">syft_0.93.0_windows_amd64.zip</span>
+    <span data-view-component="true" class="Truncate-text"></span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-sm-left flex-auto ml-md-3">15.1 MB</span>
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:38:23Z" class="no-wrap" prefix="">2023-10-10T17:38:23Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path d="M3.5 1.75v11.5c0 .09.048.173.126.217a.75.75 0 0 1-.752 1.298A1.748 1.748 0 0 1 2 13.25V1.75C2 .784 2.784 0 3.75 0h5.586c.464 0 .909.185 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v8.586A1.75 1.75 0 0 1 12.25 15h-.5a.75.75 0 0 1 0-1.5h.5a.25.25 0 0 0 .25-.25V4.664a.25.25 0 0 0-.073-.177L9.513 1.573a.25.25 0 0 0-.177-.073H7.25a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5h-3a.25.25 0 0 0-.25.25Zm3.75 8.75h.5c.966 0 1.75.784 1.75 1.75v3a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1-.75-.75v-3c0-.966.784-1.75 1.75-1.75ZM6 5.25a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 6 5.25Zm.75 2.25h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5ZM8 6.75A.75.75 0 0 1 8.75 6h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 8 6.75ZM8.75 3h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5ZM8 9.75A.75.75 0 0 1 8.75 9h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 8 9.75Zm-1 2.5v2.25h1v-2.25a.25.25 0 0 0-.25-.25h-.5a.25.25 0 0 0-.25.25Z"></path>
+</svg>
+        <a href="/anchore/syft/archive/refs/tags/v0.93.0.zip" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">Source code</span>
+    <span data-view-component="true" class="Truncate-text">(zip)</span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:27:02Z" class="no-wrap" prefix="">2023-10-10T17:27:02Z</relative-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">      <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path d="M3.5 1.75v11.5c0 .09.048.173.126.217a.75.75 0 0 1-.752 1.298A1.748 1.748 0 0 1 2 13.25V1.75C2 .784 2.784 0 3.75 0h5.586c.464 0 .909.185 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v8.586A1.75 1.75 0 0 1 12.25 15h-.5a.75.75 0 0 1 0-1.5h.5a.25.25 0 0 0 .25-.25V4.664a.25.25 0 0 0-.073-.177L9.513 1.573a.25.25 0 0 0-.177-.073H7.25a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5h-3a.25.25 0 0 0-.25.25Zm3.75 8.75h.5c.966 0 1.75.784 1.75 1.75v3a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1-.75-.75v-3c0-.966.784-1.75 1.75-1.75ZM6 5.25a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 6 5.25Zm.75 2.25h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5ZM8 6.75A.75.75 0 0 1 8.75 6h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 8 6.75ZM8.75 3h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5ZM8 9.75A.75.75 0 0 1 8.75 9h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 8 9.75Zm-1 2.5v2.25h1v-2.25a.25.25 0 0 0-.25-.25h-.5a.25.25 0 0 0-.25.25Z"></path>
+</svg>
+        <a href="/anchore/syft/archive/refs/tags/v0.93.0.tar.gz" rel="nofollow" data-turbo="false" data-view-component="true" class="Truncate">
+    <span data-view-component="true" class="Truncate-text text-bold">Source code</span>
+    <span data-view-component="true" class="Truncate-text">(tar.gz)</span>
+</a></div>      <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+          <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><relative-time datetime="2023-10-10T17:27:02Z" class="no-wrap" prefix="">2023-10-10T17:27:02Z</relative-time></span>
+</div></li>
+</ul>  
+</div>

--- a/tool/hostedshell/installer.go
+++ b/tool/hostedshell/installer.go
@@ -37,12 +37,14 @@ func NewInstaller(cfg InstallerParameters) Installer {
 }
 
 func (i Installer) InstallTo(version, destDir string) (string, error) {
-	log.WithFields("url", i.config.URL, "version", version).Debug("installing from hosted shell script")
+	lgr := log.Nested("tool", fmt.Sprintf("%s@%s", i.config.URL, version))
+
+	lgr.Debug("installing from hosted shell script")
 
 	const scriptName = "install.sh"
 
 	scriptPath := filepath.Join(destDir, scriptName)
-	if err := internal.DownloadFile(i.config.URL, scriptPath, ""); err != nil {
+	if err := internal.DownloadFile(lgr, i.config.URL, scriptPath, ""); err != nil {
 		return "", fmt.Errorf("failed to download script: %v", err)
 	}
 


### PR DESCRIPTION
The github v4 api is a little heavy for the github installer strategy in binny. Specifically a github token is required for use at all, and though the v3 api does not require this, it fetches a lot more information (is slower) and has pretty strict rate limiting. For this reason I've decided to add multiple strategies for fetching release information. 

For installing, 3 strategies are attempted in the following order:
- scrape the `https://github.com/<user>/<repo>/releases/expanded_assets/<tag-or-latest>` endpoint that drives the github UI. This is brittle, however, is the quickest way to get a list of all assets for a release universally. The risk is that GitHub may decide to change this endpoint at any time in the future for no reason or warning.
- guess a variety of `checksums.txt` assets that may or may not be there, then use the contents for a listing of assets. This is not universally guaranteed and there are a few common patterns to try so it is not an ideal solution to use as a default.
- use the v4 api as done today, which requires a token. (note: a better error message is now provided when there is no token available).

For updating the version locks, 2 strategies are attempted in the following order:
- fetch the latest release tag from `https://github.com/<user>/<repo>/releases/latest` (accepting `application/json`)
- use the v4 api as done today to get all releases, which requires a token.

For an update strategy to be deemed working, the result must not be empty and must also satisfy any user-given version constraint, otherwise the next strategy is attempted.

These updates will make binny not only faster but also not require a github token by default 🎉 