### PR TITLE
Avoid installing across filesystem boundaries

### DIFF
--- a/store.go
+++ b/store.go
@@ -152,6 +152,7 @@ func (s *Store) AddTool(toolName string, resolvedVersion, pathOutsideRoot string
 	// move the file into the store at root/basename
 	targetName := toolName
 	targetPath := filepath.Join(s.root, toolName)
+
 	if err := os.Rename(pathOutsideRoot, targetPath); err != nil {
 		return err
 	}


### PR DESCRIPTION
It was reported on slack that using `binny` didn't work and failed with an error `invalid cross-device link`

![image](https://github.com/anchore/binny/assets/590471/cf651164-8675-455a-ad69-9d4966c9a0c4)

This is because `os.Rename` was used when moving the temp directory that contains a new tool installation to the final destination within the store. I attempting using a copy first instead of a move, however, if the binary in question is still in use, then you will see an error `text in busy`. Instead the change is to use a tmp directory path to be within the store path itself, so that `os.Rename` can still be used.

CC: @brian-ebarb