### PR TITLE
Windows compat tasks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Prevent CRLF correction from changing digest of
+# text files that are committed as stand-ins for binaries
+# in text fixtures:
+/tool/testdata/store/** -text

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -27,3 +27,14 @@ jobs:
 
       - name: Run all validations
         run: make pr-validations
+
+    name: "Windows units"
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install make
+        run: "choco install make"
+
+      - name: run units
+        run: "make unit"

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Run all validations
         run: make pr-validations
 
+  WindowsValidations:
     name: "Windows units"
     runs-on: windows-2022
     steps:

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ TASK = $(TOOL_DIR)/task
 ## Bootstrapping targets #################################
 
 $(BINNY):
-	@mkdir -p $(TOOL_DIR)
-	@# we don't have a release of binny yet, so build off of the current branch
-	@#curl -sSfL https://raw.githubusercontent.com/$(OWNER)/$(PROJECT)/main/install.sh | sh -s -- -b $(TOOL_DIR)
+	@-mkdir $(TOOL_DIR)
+# we don't have a release of binny yet, so build off of the current branch
+# curl -sSfL https://raw.githubusercontent.com/$(OWNER)/$(PROJECT)/main/install.sh | sh -s -- -b $(TOOL_DIR)
 	go build -o $(TOOL_DIR)/$(PROJECT) ./cmd/$(PROJECT)
 
 .PHONY: task

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -122,7 +122,7 @@ tasks:
     desc: Run all unit tests
     vars:
       TEST_PKGS:
-          sh: "go list ./... | grep -v {{ .OWNER }}/{{ .PROJECT }}/test | tr '\n' ' '"
+          sh: "python ./scripts/list_units.py anchore binny"
 
       # unit test coverage threshold (in % coverage)
       COVERAGE_THRESHOLD: 45

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -131,7 +131,7 @@ tasks:
       - cmd: "{{ .MAKEDIR_P }} {{ .TMP_DIR }}"
         silent: true
       - "go test -coverprofile {{ .TMP_DIR }}/unit-coverage-details.txt {{ .TEST_PKGS }}"
-      - cmd: ".github/scripts/coverage.py {{ .COVERAGE_THRESHOLD }} {{ .TMP_DIR }}/unit-coverage-details.txt"
+      - cmd: '{{if eq OS "windows"}}python {{end}}.github/scripts/coverage.py {{ .COVERAGE_THRESHOLD }} {{ .TMP_DIR }}/unit-coverage-details.txt'
         silent: true
 
   ## Build-related targets #################################

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -126,7 +126,7 @@ tasks:
           sh: "python ./scripts/list_units.py anchore binny"
 
       # unit test coverage threshold (in % coverage)
-      COVERAGE_THRESHOLD: 45
+      COVERAGE_THRESHOLD: '{{if eq OS "windows"}} 43 {{else}} 45 {{end}}'
     cmds:
       - cmd: "{{ .MAKEDIR_P }} {{ .TMP_DIR }}"
         silent: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -9,6 +9,7 @@ vars:
   SNAPSHOT_DIR: snapshot
   CHANGELOG: CHANGELOG.md
   NEXT_VERSION: VERSION
+  MAKEDIR_P: 'python -c "import sys; import os; os.makedirs(sys.argv[1], exist_ok=True)"'
 
 tasks:
 
@@ -127,7 +128,7 @@ tasks:
       # unit test coverage threshold (in % coverage)
       COVERAGE_THRESHOLD: 45
     cmds:
-      - cmd: "mkdir -p {{ .TMP_DIR }}"
+      - cmd: "{{ .MAKEDIR_P }} {{ .TMP_DIR }}"
         silent: true
       - "go test -coverprofile {{ .TMP_DIR }}/unit-coverage-details.txt {{ .TEST_PKGS }}"
       - cmd: ".github/scripts/coverage.py {{ .COVERAGE_THRESHOLD }} {{ .TMP_DIR }}/unit-coverage-details.txt"

--- a/scripts/list_units.py
+++ b/scripts/list_units.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+
+def go_list_exclude_pattern(owner, project):
+    exclude_pattern = f"{owner}/{project}/test"
+
+    result = subprocess.run(["go", "list", "./..."], stdout=subprocess.PIPE, text=True, check=True)
+
+    filtered_lines = [line for line in result.stdout.splitlines() if exclude_pattern not in line]
+
+    joined_output = ' '.join(filtered_lines)
+
+    return joined_output
+
+owner = sys.argv[1]
+project = sys.argv[2]
+output = go_list_exclude_pattern(owner, project)
+print(output)

--- a/store.go
+++ b/store.go
@@ -133,15 +133,9 @@ func (s *Store) AddTool(toolName string, resolvedVersion, pathOutsideRoot string
 		}
 	}
 
-	file, err := os.Open(pathOutsideRoot)
+	digests, err := getDigestsForFile(pathOutsideRoot)
 	if err != nil {
-		return fmt.Errorf("failed to open temp copy of binary %q: %w", pathOutsideRoot, err)
-	}
-	defer file.Close()
-
-	digests, err := getDigestsForReader(file)
-	if err != nil {
-		return nil
+		return err
 	}
 
 	sha256Hash, ok := digests[internal.SHA256Algorithm]
@@ -336,6 +330,16 @@ func xxh64File(path string) (string, error) {
 	}
 
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func getDigestsForFile(filePath string) (map[string]string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open temp copy of binary %q: %w", filePath, err)
+	}
+	defer file.Close()
+
+	return getDigestsForReader(file)
 }
 
 func getDigestsForReader(r io.Reader) (map[string]string, error) {

--- a/store_test.go
+++ b/store_test.go
@@ -3,6 +3,7 @@ package binny
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -104,6 +105,9 @@ func TestStore_GetByName(t *testing.T) {
 }
 
 func TestStore_Entries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test fixtures have different sha256 digests on Windows due to linbreak conversion")
+	}
 	tests := []struct {
 		name      string
 		storeRoot string

--- a/store_test.go
+++ b/store_test.go
@@ -223,6 +223,7 @@ func TestStore_AddTool(t *testing.T) {
 
 	createFile := func(path, contents string) {
 		fh, err := os.Create(path)
+		defer fh.Close()
 		require.NoError(t, err)
 		_, err = fh.WriteString(contents)
 		require.NoError(t, err)

--- a/tool/githubrelease/installer.go
+++ b/tool/githubrelease/installer.go
@@ -133,13 +133,13 @@ func (i Installer) InstallTo(version, destDir string) (string, error) {
 }
 
 func downloadAndExtractAsset(lgr logger.Logger, asset ghAsset, checksumAsset *ghAsset, destDir string) (string, error) {
-	assetPath := path.Join(destDir, asset.Name)
+	assetPath := filepath.Join(destDir, asset.Name)
 
 	checksum := asset.Checksum
 	if checksumAsset != nil && checksum == "" {
 		lgr.WithFields("asset", checksumAsset.Name).Trace("downloading checksum manifest")
 
-		checksumsPath := path.Join(destDir, checksumsFilename)
+		checksumsPath := filepath.Join(destDir, checksumsFilename)
 
 		if err := internal.DownloadFile(lgr, checksumAsset.URL, checksumsPath, ""); err != nil {
 			return "", fmt.Errorf("unable to download checksum asset %q: %w", checksumAsset.Name, err)

--- a/tool/githubrelease/installer_test.go
+++ b/tool/githubrelease/installer_test.go
@@ -290,7 +290,9 @@ func Test_findBinaryAssetInDir(t *testing.T) {
 			got, err := findBinaryAssetInDir(tt.destDir)
 			tt.wantErr(t, err)
 
-			assert.Equal(t, tt.want, got)
+			want := strings.ReplaceAll(tt.want, "/", string(os.PathSeparator))
+
+			assert.Equal(t, want, got)
 		})
 	}
 }

--- a/tool/goinstall/installer_test.go
+++ b/tool/goinstall/installer_test.go
@@ -2,6 +2,8 @@ package goinstall
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -108,6 +110,7 @@ func TestInstaller_InstallTo(t *testing.T) {
 			i.goInstallRunner = tt.fields.goInstallRunner
 
 			got, err := i.InstallTo(tt.args.version, tt.args.destDir)
+			got = strings.ReplaceAll(got, string(os.PathSeparator), "/")
 			if !tt.wantErr(t, err, fmt.Sprintf("InstallTo(%v, %v)", tt.args.version, tt.args.destDir)) {
 				return
 			}

--- a/tool/hostedshell/installer.go
+++ b/tool/hostedshell/installer.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"text/template"
 
@@ -113,6 +114,10 @@ func templateFlags(args string, version, destination string) (string, error) {
 }
 
 func runScript(scriptPath, argStr string) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("script based installers are not supported on %s", runtime.GOOS)
+	}
+
 	userArgs, err := shlex.Split(argStr)
 	if err != nil {
 		return fmt.Errorf("failed to parse args: %v", err)

--- a/tool/hostedshell/installer_test.go
+++ b/tool/hostedshell/installer_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,10 @@ import (
 )
 
 func TestInstaller_InstallTo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script based installer is not supported on windows")
+	}
+
 	type fields struct {
 		config       InstallerParameters
 		scriptRunner func(scriptPath string, argStr string) error


### PR DESCRIPTION
This is a step towards supporting windows (see #17).

The main goal of this branch is to make the Taskfile stop depending on shell core utils to define variables, for example `go list ./... | grep -v {{ .OWNER }}/{{ .PROJECT }}/test | tr '\n' ' '` will fail on Windows because `grep` and `tr` are not guaranteed to be on PATH.

Since Python will be available, this branch experiments with python, either in separate files or inline, to perform this work. Requiring Python as a dev dependency seems reasonable, since Python is very widely used. The other choice is maintaining parallel sets of commands in `sh` and `powershell`, but I think contributors are much more likely to be comfortable in Python than powershell. In other words, requiring contributors to install Python seems less onerous than requiring them to learn powershell. Additionally, I've done some experiments in powershell, and a lot of things that are very quick one-liners in sh, (e.g. `<something> | grep -v <something-else>` or `test -f <some-file>`) are pretty lengthy powershell invocations.