### PR TITLE
Select binary within a github release archive when multiple present

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -17,14 +17,14 @@ tools:
 
   - name: gh
     version:
-      want: v2.35.0
+      want: v2.67.0
     method: github-release
     with:
       repo: cli/cli
 
   - name: quill
     version:
-      want: v0.4.1
+      want: v0.5.1
     method: github-release
     with:
       repo: anchore/quill
@@ -45,21 +45,21 @@ tools:
 
   - name: glow
     version:
-      want: v1.5.1
+      want: v2.1.0
     method: github-release
     with:
       repo: charmbracelet/glow
 
   - name: goreleaser
     version:
-      want: v1.21.1
+      want: v2.7.0
     method: github-release
     with:
       repo: goreleaser/goreleaser
 
   - name: golangci-lint
     version:
-      want: v1.54.2
+      want: v1.64.6
     method: github-release
     with:
       repo: golangci/golangci-lint
@@ -73,14 +73,14 @@ tools:
 
   - name: task
     version:
-      want: v3.30.1
+      want: v3.41.0
     method: github-release
     with:
       repo: go-task/task
 
   - name: syft
     version:
-      want: v0.91.0
+      want: v1.20.0
     method: github-release
     with:
       repo: anchore/syft

--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -4,7 +4,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: true
-    default: "1.21.x"
+    default: "1.24.x"
   cache-key-prefix:
     description: "Prefix all cache keys with this value"
     required: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,8 @@
 issues:
   max-same-issues: 25
+  uniq-by-line: false
 
-  # TODO: enable this when we have coverage on docstring comments
+# TODO: enable this when we have coverage on docstring comments
 #  # The list of ids of default excludes to include or disable.
 #  include:
 #    - EXC0002 # disable excluding of issues about comments from golint
@@ -12,10 +13,10 @@ linters:
   enable:
     - asciicheck
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - funlen
     - gocognit
     - goconst
@@ -30,6 +31,7 @@ linters:
     - ineffassign
     - misspell
     - nakedret
+    - nolintlint
     - revive
     - staticcheck
     - stylecheck
@@ -49,10 +51,12 @@ linters-settings:
     # If lower than 0, disable the check.
     # Default: 40
     statements: 50
-output:
-  uniq-by-line: false
+  gosec:
+    excludes:
+      - G115
 run:
   timeout: 10m
+  tests: false
 
 # do not enable...
 #    - deadcode          # The owner seems to have abandoned the linter. Replaced by "unused".
@@ -72,7 +76,6 @@ run:
 #    - lll         # without a way to specify per-line exception cases, this is not usable
 #    - maligned    # this is an excellent linter, but tricky to optimize and we are not sensitive to memory layout optimizations
 #    - nestif
-#    - nolintlint   # as of go1.19 this conflicts with the behavior of gofmt, which is a deal-breaker (lint-fix will still fail when running lint)
 #    - prealloc     # following this rule isn't consistently a good idea, as it sometimes forces unnecessary allocations that result in less idiomatic code
 #    - rowserrcheck # not in a repo with sql, so this is not useful
 #    - scopelint    # deprecated

--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ The `version.want` option allows a special entry:
 
 The `github-release` version method uses the GitHub Releases API to determine the latest release of a tool. It requires the following configuration options:
 
-| Option | Description                                                                                     |
-|--------|-------------------------------------------------------------------------------------------------|
-| `repo` | The GitHub repository to reference releases from. This should be in the format `<owner>/<repo>` |
+| Option   | Description                                                                                     |
+|----------|-------------------------------------------------------------------------------------------------|
+| `binary` | Binary to select if there are multiple within the release archive (defaults to the tool name)   |
+| `repo`   | The GitHub repository to reference releases from. This should be in the format `<owner>/<repo>` |
 
 The `version.want` option allows a special entry:
 - `latest`: don't pin to a version, use the latest available

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -146,7 +146,7 @@ tasks:
           sh: "python ./scripts/list_units.py anchore binny"
 
       # unit test coverage threshold (in % coverage)
-      COVERAGE_THRESHOLD: '{{if eq OS "windows"}} 43 {{else}} 45 {{end}}'
+      COVERAGE_THRESHOLD: 35
     cmds:
       - cmd: "{{ .MAKEDIR_P }} {{ .TMP_DIR }}"
         silent: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -59,18 +59,35 @@ tasks:
   tools:
     desc: Install all tools needed for CI and local development
     deps: [binny]
+    aliases:
+      - bootstrap
     generates:
-      - "{{ .TOOL_DIR }}/binny"
-      - "{{ .TOOL_DIR }}/goreleaser"
-      - "{{ .TOOL_DIR }}/chronicle"
-      - "{{ .TOOL_DIR }}/glow"
-      - "{{ .TOOL_DIR }}/golangci-lint"
-      - "{{ .TOOL_DIR }}/gosimports"
-      - "{{ .TOOL_DIR }}/bouncer"
-      - "{{ .TOOL_DIR }}/task"
+      - ".binny.yaml"
+      - "{{ .TOOL_DIR }}/*"
     status:
       - "{{ .TOOL_DIR }}/binny check -v"
     cmd: "{{ .TOOL_DIR }}/binny install -v"
+    silent: true
+
+  update-tools:
+    desc: Update pinned versions of all tools to their latest available versions
+    deps: [binny]
+    generates:
+      - ".binny.yaml"
+      - "{{ .TOOL_DIR }}/*"
+    cmd: "{{ .TOOL_DIR }}/binny update -v"
+    silent: true
+
+  list-tools:
+    desc: List all tools needed for CI and local development
+    deps: [binny]
+    cmd: "{{ .TOOL_DIR }}/binny list"
+    silent: true
+
+  list-tool-updates:
+    desc: List all tools that are not up to date relative to the binny config
+    deps: [binny]
+    cmd: "{{ .TOOL_DIR }}/binny list --updates"
     silent: true
 
 

--- a/cmd/binny/cli/command/add_github_release.go
+++ b/cmd/binny/cli/command/add_github_release.go
@@ -30,13 +30,13 @@ func AddGithubRelease(app clio.Application) *cobra.Command {
 		Use:   "github-release OWNER/REPO@VERSION",
 		Short: "Add a new tool configuration that sources binaries from GitHub releases",
 		Args:  cobra.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			if !strings.Contains(args[0], "/") {
 				return fmt.Errorf("invalid 'owner/project@version' format: %q", args[0])
 			}
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return runGithubReleaseConfig(*cfg, args[0])
 		},
 	}, cfg)

--- a/cmd/binny/cli/command/add_go_install.go
+++ b/cmd/binny/cli/command/add_go_install.go
@@ -35,13 +35,13 @@ func AddGoInstall(app clio.Application) *cobra.Command {
 		Use:   "go-install NAME@VERSION --module GOMODULE [--entrypoint PATH] [--ldflags FLAGS]",
 		Short: "Add a new tool configuration from 'go install ...' invocations",
 		Args:  cobra.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if cfg.Install.GoInstall.Module == "" {
 				return fmt.Errorf("go-install configuration requires '--module' option")
 			}
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return runAddGoInstallConfig(*cfg, args[0])
 		},
 	}, cfg)

--- a/cmd/binny/cli/command/check.go
+++ b/cmd/binny/cli/command/check.go
@@ -33,11 +33,11 @@ func Check(app clio.Application) *cobra.Command {
 		Use:   "check",
 		Short: "Verify tool are installed at the configured version",
 		Args:  cobra.ArbitraryArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			names = args
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runCheck(*cfg, names)
 		},
 	}, cfg)

--- a/cmd/binny/cli/command/install.go
+++ b/cmd/binny/cli/command/install.go
@@ -39,11 +39,11 @@ func Install(app clio.Application) *cobra.Command {
 		Use:   "install",
 		Short: "Install tools",
 		Args:  cobra.ArbitraryArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			names = args
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runInstall(*cfg, names)
 		},
 	}, cfg)
@@ -115,7 +115,7 @@ func runInstall(cmdCfg InstallConfig, names []string) error {
 	}
 
 	// note: we can ignore the error here because we are tracking the error through the multierror object
-	g.Wait() // nolint: errcheck
+	g.Wait() //nolint: errcheck
 
 	alreadyInstalled = len(alreadyInstalledTools) > 0 && len(alreadyInstalledTools) == len(toolOpts)
 

--- a/cmd/binny/cli/command/install.go
+++ b/cmd/binny/cli/command/install.go
@@ -49,8 +49,7 @@ func Install(app clio.Application) *cobra.Command {
 	}, cfg)
 }
 
-// nolint: funlen
-func runInstall(cmdCfg InstallConfig, names []string) error {
+func runInstall(cmdCfg InstallConfig, names []string) error { //nolint: funlen
 	names, toolOpts := selectNamesAndConfigs(cmdCfg.Core, names)
 
 	if len(toolOpts) == 0 {

--- a/cmd/binny/cli/command/list.go
+++ b/cmd/binny/cli/command/list.go
@@ -44,14 +44,14 @@ func List(app clio.Application) *cobra.Command {
 			"ls",
 		},
 		Args: cobra.ArbitraryArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			if cfg.Format.JQCommand != "" && cfg.Format.Output != "json" {
 				return fmt.Errorf("--jq can only be used when --output format is 'json'")
 			}
 			cfg.IncludeFilter = args
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runList(*cfg)
 		},
 	}, cfg)

--- a/cmd/binny/cli/command/run.go
+++ b/cmd/binny/cli/command/run.go
@@ -29,7 +29,7 @@ func Run(app clio.Application) *cobra.Command {
 		Short:              "run a specific tool",
 		DisableFlagParsing: true, // pass these as arguments to the tool
 		Args:               cobra.ArbitraryArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("no tool name provided")
 			}

--- a/cmd/binny/cli/command/update.go
+++ b/cmd/binny/cli/command/update.go
@@ -76,8 +76,7 @@ func (p updateLockYamlPatcher) PatchYaml(node *yaml.Node) error {
 	return nil
 }
 
-// nolint: funlen,gocognit
-func getUpdatedConfig(cfg UpdateConfig, names []string) (*option.Core, error) {
+func getUpdatedConfig(cfg UpdateConfig, names []string) (*option.Core, error) { //nolint: funlen,gocognit
 	var (
 		errs                 error
 		newCfgs              []option.Tool

--- a/cmd/binny/cli/command/update.go
+++ b/cmd/binny/cli/command/update.go
@@ -39,11 +39,11 @@ func Update(app clio.Application) *cobra.Command {
 		Use:   "update",
 		Short: "Update pinned tool version configuration with latest available versions (that are still within any provided constraints)",
 		Args:  cobra.ArbitraryArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			names = args
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runUpdate(*cfg, names)
 		},
 	}, cfg)
@@ -160,7 +160,7 @@ func getUpdatedConfig(cfg UpdateConfig, names []string) (*option.Core, error) {
 	}
 
 	// note: we can ignore the error here because we are tracking the error through the multierror object
-	g.Wait() // nolint: errcheck
+	g.Wait() //nolint: errcheck
 
 	newCfg := cfg
 	newCfg.Tools = newCfgs

--- a/cmd/binny/cli/option/tool.go
+++ b/cmd/binny/cli/option/tool.go
@@ -44,7 +44,7 @@ func (t Tool) ToTool() (binny.Tool, *binny.VersionIntent, error) {
 }
 
 func (t Tool) ToConfig() (*tool.Config, *binny.VersionIntent, error) {
-	installParams, err := deriveInstallParameters(t.InstallMethod, t.Parameters)
+	installParams, err := deriveInstallParameters(t.Name, t.InstallMethod, t.Parameters)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to derive install parameters for tool %q: %w", t.Name, err)
 	}
@@ -74,7 +74,7 @@ func (t Tool) ToConfig() (*tool.Config, *binny.VersionIntent, error) {
 	return cfg, intent, nil
 }
 
-func deriveInstallParameters(installMethod string, installParams map[string]any) (any, error) {
+func deriveInstallParameters(name string, installMethod string, installParams map[string]any) (any, error) {
 	switch {
 	case goinstall.IsInstallMethod(installMethod):
 		var params goinstall.InstallerParameters
@@ -94,6 +94,10 @@ func deriveInstallParameters(installMethod string, installParams map[string]any)
 		var params githubrelease.InstallerParameters
 		if err := mapstructure.Decode(installParams, &params); err != nil {
 			return nil, err
+		}
+		if params.Binary == "" {
+			// if not provided, assume that the binary name is the same as the configured tool name
+			params.Binary = name
 		}
 		return params, nil
 	case installMethod == "":

--- a/cmd/binny/cli/option/tool_test.go
+++ b/cmd/binny/cli/option/tool_test.go
@@ -1,0 +1,71 @@
+package option
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/binny/tool/githubrelease"
+)
+
+func TestDeriveInstallParameters_GithubRelease(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    map[string]any
+		goos      string
+		expected  githubrelease.InstallerParameters
+		expectErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "valid parameters with binary name",
+			params: map[string]any{
+				"binary": "mytool",
+				"repo":   "owner/repo",
+			},
+			goos:      "linux",
+			expected:  githubrelease.InstallerParameters{Binary: "mytool", Repo: "owner/repo"},
+			expectErr: require.NoError,
+		},
+		{
+			name: "missing binary name, should default to tool name on Linux",
+			params: map[string]any{
+				"repo": "owner/repo",
+			},
+			goos:      "linux",
+			expected:  githubrelease.InstallerParameters{Binary: "mytool", Repo: "owner/repo"},
+			expectErr: require.NoError,
+		},
+		{
+			name: "missing binary name, should default to tool name with .exe on Windows",
+			params: map[string]any{
+				"repo": "owner/repo",
+			},
+			goos:      "windows",
+			expected:  githubrelease.InstallerParameters{Binary: "mytool.exe", Repo: "owner/repo"},
+			expectErr: require.NoError,
+		},
+		{
+			name: "bad data shape should return an error",
+			params: map[string]any{
+				"binary": map[string]string{"bogus": "BogOsiTy"},
+			},
+			goos:      "linux",
+			expectErr: require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := deriveInstallParameters("mytool", "githubrelease", tt.params, tt.goos)
+			if tt.expectErr == nil {
+				tt.expectErr = require.NoError
+			}
+			tt.expectErr(t, err)
+			if err == nil {
+				instParams, ok := result.(githubrelease.InstallerParameters)
+				require.True(t, ok)
+				require.Equal(t, tt.expected, instParams)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/binny
 
-go 1.21.1
+go 1.24.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/internal/download_file.go
+++ b/internal/download_file.go
@@ -1,8 +1,8 @@
 package internal
 
 import (
-	"crypto/md5"  // nolint:gosec // MD5 is used for legacy compatibility
-	"crypto/sha1" // nolint:gosec // SHA1 is used for legacy compatibility
+	"crypto/md5"  //nolint:gosec // MD5 is used for legacy compatibility
+	"crypto/sha1" //nolint:gosec // SHA1 is used for legacy compatibility
 	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
@@ -53,7 +53,7 @@ func DownloadFile(lgr logger.Logger, url string, filepath string, checksum strin
 }
 
 func DownloadURL(lgr logger.Logger, url string) (io.ReadCloser, error) {
-	resp, err := http.Get(url) // nolint: gosec  // we must be able to get arbitrary URLs
+	resp, err := http.Get(url) //nolint: gosec  // we must be able to get arbitrary URLs
 	if err != nil {
 		return nil, fmt.Errorf("unable to download %q: %w", url, err)
 	}
@@ -90,11 +90,11 @@ func getHasher(checksum string) hash.Hash {
 	case "sha256":
 		return sha256.New()
 	case "sha1":
-		return sha1.New() // nolint:gosec // SHA1 is used for legacy compatibility
+		return sha1.New() //nolint:gosec // SHA1 is used for legacy compatibility
 	case "sha512":
 		return sha512.New()
 	case "md5":
-		return md5.New() // nolint:gosec // MD5 is used for legacy compatibility
+		return md5.New() //nolint:gosec // MD5 is used for legacy compatibility
 	default:
 		return defaultHash
 	}

--- a/internal/semver.go
+++ b/internal/semver.go
@@ -33,20 +33,20 @@ func FilterToLatestVersion(versions []string, versionConstraint string) (string,
 		}
 	}
 
-	var max *semver.Version
+	var maxVal *semver.Version
 	for _, v := range parsed {
 		if constraint != nil && !constraint.Check(v) {
 			continue
 		}
-		if max == nil || v.GreaterThan(max) {
-			max = v
+		if maxVal == nil || v.GreaterThan(maxVal) {
+			maxVal = v
 		}
 	}
 
-	if max == nil {
+	if maxVal == nil {
 		return "", nil
 	}
-	return max.Original(), nil
+	return maxVal.Original(), nil
 }
 
 func IsSemver(v string) bool {

--- a/test/cli/utils_test.go
+++ b/test/cli/utils_test.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -128,7 +127,7 @@ func getBinaryLocationByOS(t testing.TB, goOS string) string {
 	// note: there is a subtle - vs _ difference between these versions
 	switch goOS {
 	case "darwin", "linux":
-		return path.Join(repoRoot(t), fmt.Sprintf("snapshot/%s-build_%s_%s/binny", goOS, goOS, archPath))
+		return filepath.Join(repoRoot(t), "snapshot", fmt.Sprintf("%s-build_%s_%s", goOS, goOS, archPath), "binny")
 	default:
 		t.Fatalf("unsupported OS: %s", runtime.GOOS)
 	}

--- a/tool/githubrelease/installer.go
+++ b/tool/githubrelease/installer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -202,7 +201,7 @@ func isBinaryAsset(asset ghAsset) bool {
 }
 
 func hasArchiveExtension(name string) bool {
-	ext := path.Ext(name)
+	ext := filepath.Ext(name)
 	switch ext {
 	// note: we only need to check for the last part of any archive extension (that is, only ".gz" not ".tar.gz")
 	case ".tar", ".zip", ".gz", ".bz2", ".xz", ".rar", ".7z", ".tgz", ".bz", ".tbz", ".zst", ".zstd":
@@ -271,7 +270,7 @@ func findBinaryAssetInDir(binary, destDir string) (string, error) {
 	ignore := strset.New("LICENSE", "README.md", checksumsFilename)
 	var filteredPaths []string
 	for _, p := range paths {
-		if ignore.Has(path.Base(p)) {
+		if ignore.Has(filepath.Base(p)) {
 			continue
 		}
 		filteredPaths = append(filteredPaths, p)
@@ -282,7 +281,7 @@ func findBinaryAssetInDir(binary, destDir string) (string, error) {
 	case 0:
 		return "", fmt.Errorf("no files found in %q", destDir)
 	case 1:
-		if binary != "" && binary != path.Base(filteredPaths[0]) {
+		if binary != "" && binary != filepath.Base(filteredPaths[0]) {
 			return "", fmt.Errorf("binary file %q not found in %q (found %q)", binary, destDir, filteredPaths[0])
 		}
 
@@ -319,7 +318,7 @@ func filterMultipleArchiveBinaries(binary string, destDir string, filteredPaths 
 	case 0:
 		return "", fmt.Errorf("no binary files found in %q", destDir)
 	case 1:
-		if binary != "" && binary != path.Base(candidates[0]) {
+		if binary != "" && binary != filepath.Base(candidates[0]) {
 			return "", fmt.Errorf("binary file %q not found in %q (found %q)", binary, destDir, candidates[0])
 		}
 
@@ -327,7 +326,7 @@ func filterMultipleArchiveBinaries(binary string, destDir string, filteredPaths 
 	default:
 		if binary != "" {
 			for _, p := range candidates {
-				if binary == path.Base(p) {
+				if binary == filepath.Base(p) {
 					binPath = p
 				}
 			}
@@ -488,7 +487,7 @@ func normalizedAssetName(name string) string {
 }
 
 func hasBinaryExtension(name string) bool {
-	ext := path.Ext(name)
+	ext := filepath.Ext(name)
 	switch ext {
 	case ".exe", "":
 		return true
@@ -747,7 +746,7 @@ func processExpandedAssets(lgr logger.Logger, reader io.Reader, from string) []g
 				for _, attr := range token.Attr {
 					if attr.Key == "href" && strings.Contains(attr.Val, "/releases/download/") {
 						assets = append(assets, ghAsset{
-							Name:        path.Base(attr.Val),
+							Name:        filepath.Base(attr.Val),
 							ContentType: "",
 							URL:         fmt.Sprintf("https://github.com%s", attr.Val),
 						})

--- a/tool/githubrelease/methods.go
+++ b/tool/githubrelease/methods.go
@@ -28,7 +28,7 @@ func DefaultVersionResolverConfig(installParams any) (string, any, error) {
 		return "", nil, fmt.Errorf("invalid go install parameters")
 	}
 
-	return ResolveMethod, VersionResolutionParameters{ // nolint: gosimple
+	return ResolveMethod, VersionResolutionParameters{
 		Repo: params.Repo,
 	}, nil
 }

--- a/tool/githubrelease/version_resolver.go
+++ b/tool/githubrelease/version_resolver.go
@@ -110,7 +110,7 @@ func (v VersionResolver) findLatestVersion(versionConstraint string) (string, er
 	return latestVersion.Tag, nil
 }
 
-// nolint:gocognit
+//nolint:gocognit
 func filterToLatestVersion(releases []ghRelease, versionConstraint string) (*ghRelease, error) {
 	var constraint *semver.Constraints
 	var err error

--- a/tool/goproxy/version_resolver.go
+++ b/tool/goproxy/version_resolver.go
@@ -102,7 +102,7 @@ func availableVersionsFetcher(url string) ([]string, error) {
 
 	log.WithFields("url", url).Trace("requesting latest version")
 
-	resp, err := http.Get(url) // nolint:gosec
+	resp, err := http.Get(url) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR allows for selecting the correct binary within a github release archive with multiple binaries, defaulting to the tool name when not configured:

```yaml
# binny configuration
tools:
  - name: crane
    version:
      want: v0.20.3
    method: github-release
    with:
      repo: google/go-containerregistry
```

```
# archive contents
├── LICENSE
├── README.md
├── crane
├── gcrane
└── krane
```

Before this change binny was unable to discern between which of the 3 binaries to use, now it will select `crane`.

In the process of development I needed to update linting + tool versions (hince the extra diff).