### PR TITLE
Support for filtering assets by regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,27 @@ The `github-release` install method uses the GitHub Releases API to download the
 | Option | Description                                                                                     |
 |--------|-------------------------------------------------------------------------------------------------|
 | `repo` | The GitHub repository to reference releases from. This should be in the format `<owner>/<repo>` |
+| `assets` (optional) | Regex pattern(s) to filter release assets. Can be a single string or array of strings for priority matching |
+
+When multiple assets match the OS/architecture, the `assets` field allows you to specify which one to select:
+
+```yaml
+# single regex pattern
+- name: hugo
+  method: github-release
+  with:
+    repo: gohugoio/hugo
+    assets: "^hugo_extended_[0-9]"  # match hugo_extended but not hugo_extended_withdeploy
+
+# multiple patterns (first match wins)
+- name: tool
+  method: github-release
+  with:
+    repo: owner/tool
+    assets:
+      - "^tool_premium_[0-9]"   # try premium version first
+      - "^tool_[0-9]"           # fall back to standard version
+```
 
 The default version resolver for this method is `github-release`.
 


### PR DESCRIPTION
In cases where a github release has multiple assets to choose from (not just by version and architecture and tool name, but other build name variants). For example hugo has `hugo`, `hugo_extended`, and `hugo_extended_withdeploy` assets. This PR allows for the user to filter down to assets that they want to be considered:
```yaml
  - name: hugo
    version:
      want: v0.150.0
    method: github-release
    with:
      repo: gohugoio/hugo
      assets: ^hugo_extended_withdeploy    # single configuration
```

Or to consider multiple patterns, where the first match wins:
```yaml
  - name: hugo
    version:
      want: v0.150.0
    method: github-release
    with:
      repo: gohugoio/hugo
      assets:                              # multiple configurations
       - ^hugo_extended_withdeploy
       - ^hugo_extended
```