### PR TITLE
fix: return error and not nil to prevent panic

### DIFF
--- a/internal/download_file.go
+++ b/internal/download_file.go
@@ -61,7 +61,9 @@ func DownloadURL(lgr logger.Logger, url string) (io.ReadCloser, error) {
 	lgr.WithFields("http-status", resp.StatusCode).Tracef("http get %q", url)
 
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
 		return nil, fmt.Errorf("unexpected status code %d for %q", resp.StatusCode, url)
 	}
 	return resp.Body, nil


### PR DESCRIPTION
### Panic Trace On Failed Download
```
goroutine 36 [running]:
github.com/anchore/binny/internal.DownloadFile({0x10cc8b0, 0xc0002c6740}, {0xc000478120, 0x58}, {0xc0004795c0, 0x60}, {0xc0004782a0, 0x40})
	/home/runner/work/binny/binny/internal/download_file.go:24 +0x9c
github.com/anchore/binny/tool/githubrelease.downloadAndExtractAsset({0x10cc8b0, 0xc0002c6740}, {{0xc00011c5c8, 0x1e}, {0x0, 0x0}, {0xc000478120, 0x58}, {0x0, 0x0}}, ...)
	/home/runner/work/binny/binny/tool/githubrelease/installer.go:206 +0x5ef
github.com/anchore/binny/tool/githubrelease.Installer.InstallTo({{{0xc00045c5e4, 0x4}, {0xc00045c664, 0xc}, {0x0, 0x0}}, {0x0, 0x0, 0x0}, 0xfa4bf8}, ...)
	/home/runner/work/binny/binny/tool/githubrelease/installer.go:168 +0x44b
github.com/anchore/binny/tool.Install({0x10c7138, 0xc0001c8000}, {{0xc00045c600?, 0x6?}, {0x0?, 0x0?}}, 0xc000477a70, {0x0?, 0x0?})
	/home/runner/work/binny/binny/tool/install.go:63 +0x85c
github.com/anchore/binny/cmd/binny/cli/command.installTool(0xc000477a70, {{0xc000132100, 0xb}, 0x0, {0x0}, {{{0xf4c60e, 0x5}}, {0xc000332a08, 0xd, 0xd}}}, ...)
	/home/runner/work/binny/binny/cmd/binny/cli/command/install.go:161 +0x146
github.com/anchore/binny/cmd/binny/cli/command.runInstall.func2()
	/home/runner/work/binny/binny/cmd/binny/cli/command/install.go:97 +0xb8
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.17.0/errgroup/errgroup.go:93 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 34
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.17.0/errgroup/errgroup.go:78 +0x93
task: Failed to run task "tools": exit status 2
```

In `internal/download_file.go`, the DownloadURL function returned nil, nil when the HTTP status is not 200:
https://github.com/anchore/binny/blob/ab41ed5b995f4bab5574e59f7e58f3caee3f497a/internal/download_file.go#L63-L67

The `DownloadFile` function doesn't handle this case properly:
https://github.com/anchore/binny/blob/c2c0050eeb51078ea5b5c91f0441fc82d1354a25/internal/download_file.go#L20-L24

The err being `nil` passes to then try and run `reader.Close()` which causes a panic. This patch prevents the panic case.