### PR TITLE
refactor: pass resources through context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /.task
 /bin
 
+# local development
+.claude
+CLAUDE.md
+
 # release locations
 /snapshot
 /dist

--- a/cmd/binny/cli/command/root.go
+++ b/cmd/binny/cli/command/root.go
@@ -1,11 +1,38 @@
 package command
 
 import (
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/spf13/cobra"
 
+	internalhttp "github.com/anchore/binny/internal/http"
+	"github.com/anchore/binny/internal/log"
 	"github.com/anchore/clio"
 )
 
 func Root(app clio.Application) *cobra.Command {
-	return app.SetupRootCommand(&cobra.Command{})
+	cmd := app.SetupRootCommand(&cobra.Command{})
+
+	// wrap any existing PersistentPreRunE to inject dependencies into context
+	existingPreRunE := cmd.PersistentPreRunE
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		// inject the global logger into the context
+		lgr := log.Get()
+		ctx = log.WithLogger(ctx, lgr)
+
+		// inject a configured HTTP client into the context
+		httpClient := retryablehttp.NewClient()
+		httpClient.Logger = internalhttp.NewLeveledLogger(lgr.Nested("component", "http-client"))
+		ctx = internalhttp.WithHTTPClient(ctx, httpClient)
+
+		cmd.SetContext(ctx)
+
+		if existingPreRunE != nil {
+			return existingPreRunE(cmd, args)
+		}
+		return nil
+	}
+
+	return cmd
 }

--- a/cmd/binny/cli/command/root_test.go
+++ b/cmd/binny/cli/command/root_test.go
@@ -1,0 +1,66 @@
+package command
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internalhttp "github.com/anchore/binny/internal/http"
+	"github.com/anchore/binny/internal/log"
+	"github.com/anchore/clio"
+	"github.com/anchore/go-logger/adapter/discard"
+)
+
+func TestRoot_PersistentPreRunE_InjectsContext(t *testing.T) {
+	// set up a global logger so we have something to inject
+	log.Set(discard.New())
+
+	app := clio.New(clio.SetupConfig{
+		ID: clio.Identification{
+			Name:    "test",
+			Version: "0.0.0",
+		},
+	})
+
+	root := Root(app)
+
+	// verify PersistentPreRunE is set
+	require.NotNil(t, root.PersistentPreRunE, "PersistentPreRunE should be set")
+
+	// set a base context on the command
+	root.SetContext(context.Background())
+
+	// simulate what cobra does - call PersistentPreRunE
+	err := root.PersistentPreRunE(root, []string{})
+	require.NoError(t, err)
+
+	// verify the context now has the logger and HTTP client
+	ctx := root.Context()
+
+	// verify logger was injected by checking it's the same as the global logger
+	lgr := log.FromContext(ctx)
+	assert.NotNil(t, lgr, "logger should be in context")
+	assert.Equal(t, log.Get(), lgr, "logger from context should be the global logger we set")
+
+	// verify HTTP client was injected (not the default fallback)
+	client := internalhttp.ClientFromContext(ctx)
+	assert.NotNil(t, client, "HTTP client should be in context")
+	assert.NotNil(t, client.Logger, "HTTP client should have our leveled logger adapter")
+}
+
+func TestRoot_PersistentPreRunE_ContextNotSetWithoutPreRun(t *testing.T) {
+	// this test verifies that without calling PersistentPreRunE,
+	// we get fallback values, proving the injection is necessary
+
+	ctx := context.Background()
+
+	// without injection, FromContext falls back to global logger
+	lgr := log.FromContext(ctx)
+	assert.NotNil(t, lgr, "fallback logger should exist")
+
+	// without injection, ClientFromContext falls back to default client
+	client := internalhttp.ClientFromContext(ctx)
+	assert.NotNil(t, client, "fallback HTTP client should exist")
+}

--- a/internal/download_file_test.go
+++ b/internal/download_file_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,8 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/anchore/go-logger/adapter/discard"
 )
 
 func Test_DownloadFile(t *testing.T) {
@@ -51,7 +50,7 @@ func Test_DownloadFile(t *testing.T) {
 			dir := t.TempDir()
 			dlPath := filepath.Join(dir, "the-file-path.txt")
 
-			tt.wantErr(t, DownloadFile(discard.New(), s.URL, dlPath, tt.checksum))
+			tt.wantErr(t, DownloadFile(context.Background(), s.URL, dlPath, tt.checksum))
 
 			gotContents, err := os.ReadFile(dlPath)
 			require.NoError(t, err)

--- a/internal/http/context.go
+++ b/internal/http/context.go
@@ -1,0 +1,30 @@
+package http
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+type ctxKey struct{}
+
+// defaultClient is used when none is in context
+var defaultClient = retryablehttp.NewClient()
+
+func init() {
+	defaultClient.Logger = nil // silence default logger
+}
+
+// WithHTTPClient returns a new context with the provided HTTP client attached.
+func WithHTTPClient(ctx context.Context, client *retryablehttp.Client) context.Context {
+	return context.WithValue(ctx, ctxKey{}, client)
+}
+
+// ClientFromContext retrieves the HTTP client from context.
+// Falls back to a default retryable client if none is set.
+func ClientFromContext(ctx context.Context) *retryablehttp.Client {
+	if client, ok := ctx.Value(ctxKey{}).(*retryablehttp.Client); ok && client != nil {
+		return client
+	}
+	return defaultClient
+}

--- a/internal/http/logger_adapter.go
+++ b/internal/http/logger_adapter.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/anchore/go-logger"
+)
+
+var _ retryablehttp.LeveledLogger = (*leveledLoggerAdapter)(nil)
+
+// leveledLoggerAdapter adapts a go-logger.Logger to the retryablehttp.LeveledLogger interface.
+type leveledLoggerAdapter struct {
+	lgr logger.Logger
+}
+
+// NewLeveledLogger creates a retryablehttp.LeveledLogger from a go-logger.Logger.
+func NewLeveledLogger(lgr logger.Logger) retryablehttp.LeveledLogger {
+	return &leveledLoggerAdapter{lgr: lgr}
+}
+
+func (l *leveledLoggerAdapter) Error(msg string, keysAndValues ...interface{}) {
+	l.lgr.WithFields(keysAndValues...).Error(msg)
+}
+
+func (l *leveledLoggerAdapter) Warn(msg string, keysAndValues ...interface{}) {
+	l.lgr.WithFields(keysAndValues...).Warn(msg)
+}
+
+func (l *leveledLoggerAdapter) Info(msg string, keysAndValues ...interface{}) {
+	l.lgr.WithFields(keysAndValues...).Info(msg)
+}
+
+func (l *leveledLoggerAdapter) Debug(msg string, keysAndValues ...interface{}) {
+	l.lgr.WithFields(keysAndValues...).Debug(msg)
+}

--- a/internal/log/context.go
+++ b/internal/log/context.go
@@ -1,0 +1,29 @@
+package log
+
+import (
+	"context"
+
+	"github.com/anchore/go-logger"
+)
+
+type ctxKey struct{}
+
+// WithLogger returns a new context with the provided logger attached.
+func WithLogger(ctx context.Context, lgr logger.Logger) context.Context {
+	return context.WithValue(ctx, ctxKey{}, lgr)
+}
+
+// FromContext retrieves the logger from context. Falls back to global logger.
+func FromContext(ctx context.Context) logger.Logger {
+	if lgr, ok := ctx.Value(ctxKey{}).(logger.Logger); ok && lgr != nil {
+		return lgr
+	}
+	return Get()
+}
+
+// WithNested gets the logger from context, creates a nested logger with the provided
+// key-value fields, and returns both the new context and the nested logger.
+func WithNested(ctx context.Context, fields ...any) (context.Context, logger.Logger) {
+	lgr := FromContext(ctx).Nested(fields...)
+	return WithLogger(ctx, lgr), lgr
+}

--- a/tool.go
+++ b/tool.go
@@ -1,5 +1,7 @@
 package binny
 
+import "context"
+
 type Tool interface {
 	Name() string
 	Installer
@@ -7,12 +9,12 @@ type Tool interface {
 }
 
 type Installer interface {
-	InstallTo(version, destDir string) (string, error)
+	InstallTo(ctx context.Context, version, destDir string) (string, error)
 }
 
 type VersionResolver interface {
-	ResolveVersion(want, constraint string) (string, error)
-	UpdateVersion(want, constraint string) (string, error)
+	ResolveVersion(ctx context.Context, want, constraint string) (string, error)
+	UpdateVersion(ctx context.Context, want, constraint string) (string, error)
 }
 
 type VersionIntent struct {

--- a/tool/git/version_resolver.go
+++ b/tool/git/version_resolver.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -27,16 +28,16 @@ func NewVersionResolver(cfg VersionResolutionParameters) *VersionResolver {
 	}
 }
 
-func (v VersionResolver) UpdateVersion(want, constraint string) (string, error) {
+func (v VersionResolver) UpdateVersion(ctx context.Context, want, constraint string) (string, error) {
 	if want == "current" {
 		// always use the same reference
 		return want, nil
 	}
-	return v.ResolveVersion(want, constraint)
+	return v.ResolveVersion(ctx, want, constraint)
 }
 
-func (v VersionResolver) ResolveVersion(want, _ string) (string, error) {
-	log.WithFields("path", v.config.Path, "version", want).Trace("resolving version from git")
+func (v VersionResolver) ResolveVersion(ctx context.Context, want, _ string) (string, error) {
+	log.FromContext(ctx).WithFields("path", v.config.Path, "version", want).Trace("resolving version from git")
 
 	if want == "current" {
 		commit, err := headCommit(v.config.Path)

--- a/tool/githubrelease/retry_test.go
+++ b/tool/githubrelease/retry_test.go
@@ -1,6 +1,7 @@
 package githubrelease
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,7 +27,7 @@ func TestNewRetryableGitHubClient_RetriesWithAuthHeader(t *testing.T) {
 	defer server.Close()
 
 	token := "test-token-12345"
-	client := newRetryableGitHubClient(token)
+	client := newRetryableGitHubClient(context.Background(), token)
 
 	resp, err := client.Get(server.URL)
 	require.NoError(t, err)

--- a/tool/githubrelease/version_resolver_test.go
+++ b/tool/githubrelease/version_resolver_test.go
@@ -1,6 +1,7 @@
 package githubrelease
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,8 +14,8 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 		config               VersionResolutionParameters
 		version              string
 		constraint           string
-		releasesFetcher      func(user, repo string) ([]ghRelease, error)
-		latestReleaseFetcher func(user, repo string) (*ghRelease, error)
+		releasesFetcher      func(ctx context.Context, user, repo string) ([]ghRelease, error)
+		latestReleaseFetcher func(ctx context.Context, user, repo string) (*ghRelease, error)
 		want                 string
 		wantErr              require.ErrorAssertionFunc
 	}{
@@ -25,12 +26,12 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			},
 			version: "latest",
 			want:    "2.0.0",
-			latestReleaseFetcher: func(user, repo string) (*ghRelease, error) {
+			latestReleaseFetcher: func(_ context.Context, user, repo string) (*ghRelease, error) {
 				return &ghRelease{
 					Tag: "2.0.0",
 				}, nil
 			},
-			releasesFetcher: func(user, repo string) ([]ghRelease, error) {
+			releasesFetcher: func(_ context.Context, user, repo string) ([]ghRelease, error) {
 				t.Fatal("should not have been called")
 				return nil, nil
 			},
@@ -42,10 +43,10 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			},
 			version: "latest",
 			want:    "2.0.0",
-			latestReleaseFetcher: func(user, repo string) (*ghRelease, error) {
+			latestReleaseFetcher: func(_ context.Context, user, repo string) (*ghRelease, error) {
 				return nil, nil
 			},
-			releasesFetcher: func(user, repo string) ([]ghRelease, error) {
+			releasesFetcher: func(_ context.Context, user, repo string) ([]ghRelease, error) {
 				return []ghRelease{
 					{
 						Tag: "1.0.0",
@@ -85,7 +86,7 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			v.latestReleaseFetcher = tt.latestReleaseFetcher
 			v.releasesFetcher = tt.releasesFetcher
 
-			got, err := v.ResolveVersion(tt.version, tt.constraint)
+			got, err := v.ResolveVersion(context.Background(), tt.version, tt.constraint)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -98,8 +99,8 @@ func TestVersionResolver_UpdateVersion(t *testing.T) {
 		config               VersionResolutionParameters
 		version              string
 		constraint           string
-		releaseFetcher       func(user, repo string) ([]ghRelease, error)
-		latestReleaseFetcher func(user, repo string) (*ghRelease, error)
+		releaseFetcher       func(ctx context.Context, user, repo string) ([]ghRelease, error)
+		latestReleaseFetcher func(ctx context.Context, user, repo string) (*ghRelease, error)
 		want                 string
 		wantErr              require.ErrorAssertionFunc
 	}{
@@ -118,10 +119,10 @@ func TestVersionResolver_UpdateVersion(t *testing.T) {
 			},
 			version: "1.0.0",
 			want:    "2.0.0",
-			latestReleaseFetcher: func(user, repo string) (*ghRelease, error) {
+			latestReleaseFetcher: func(_ context.Context, user, repo string) (*ghRelease, error) {
 				return nil, nil
 			},
-			releaseFetcher: func(user, repo string) ([]ghRelease, error) {
+			releaseFetcher: func(_ context.Context, user, repo string) ([]ghRelease, error) {
 				return []ghRelease{
 					{
 						Tag: "1.0.0",
@@ -142,12 +143,12 @@ func TestVersionResolver_UpdateVersion(t *testing.T) {
 			},
 			version: "1.0.0",
 			want:    "2.0.0",
-			latestReleaseFetcher: func(user, repo string) (*ghRelease, error) {
+			latestReleaseFetcher: func(_ context.Context, user, repo string) (*ghRelease, error) {
 				return &ghRelease{
 					Tag: "2.0.0",
 				}, nil
 			},
-			releaseFetcher: func(user, repo string) ([]ghRelease, error) {
+			releaseFetcher: func(_ context.Context, user, repo string) ([]ghRelease, error) {
 				t.Fatal("should not have been called")
 				return nil, nil
 			},
@@ -170,7 +171,7 @@ func TestVersionResolver_UpdateVersion(t *testing.T) {
 			v.latestReleaseFetcher = tt.latestReleaseFetcher
 			v.releasesFetcher = tt.releaseFetcher
 
-			got, err := v.UpdateVersion(tt.version, tt.constraint)
+			got, err := v.UpdateVersion(context.Background(), tt.version, tt.constraint)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/tool/goinstall/installer.go
+++ b/tool/goinstall/installer.go
@@ -2,6 +2,7 @@ package goinstall
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -37,7 +38,8 @@ func NewInstaller(cfg InstallerParameters) Installer {
 	}
 }
 
-func (i Installer) InstallTo(version, destDir string) (string, error) {
+func (i Installer) InstallTo(ctx context.Context, version, destDir string) (string, error) {
+	lgr := log.FromContext(ctx)
 	path := i.config.Module
 	if i.config.Entrypoint != "" {
 		path += "/" + i.config.Entrypoint
@@ -50,9 +52,9 @@ func (i Installer) InstallTo(version, destDir string) (string, error) {
 	isLocal := strings.HasPrefix(i.config.Module, ".") || strings.HasPrefix(i.config.Module, "/")
 	if isLocal {
 		spec = path
-		log.WithFields("module", i.config.Module, "version", version).Debug("installing go module (local)")
+		lgr.WithFields("module", i.config.Module, "version", version).Debug("installing go module (local)")
 	} else {
-		log.WithFields("module", i.config.Module, "version", version).Debug("installing go module (remote)")
+		lgr.WithFields("module", i.config.Module, "version", version).Debug("installing go module (remote)")
 	}
 
 	ldflags, err := templateFlags(i.config.LDFlags, version)

--- a/tool/goinstall/installer_test.go
+++ b/tool/goinstall/installer_test.go
@@ -1,6 +1,7 @@
 package goinstall
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -246,7 +247,7 @@ func TestInstaller_InstallTo(t *testing.T) {
 			i := NewInstaller(tt.fields.config)
 			i.goInstallRunner = tt.fields.goInstallRunner
 
-			got, err := i.InstallTo(tt.args.version, tt.args.destDir)
+			got, err := i.InstallTo(context.Background(), tt.args.version, tt.args.destDir)
 			got = strings.ReplaceAll(got, string(os.PathSeparator), "/")
 			if !tt.wantErr(t, err, fmt.Sprintf("InstallTo(%v, %v)", tt.args.version, tt.args.destDir)) {
 				return

--- a/tool/goproxy/version_resolver_test.go
+++ b/tool/goproxy/version_resolver_test.go
@@ -1,6 +1,7 @@
 package goproxy
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -14,7 +15,7 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 		config                   VersionResolutionParameters
 		version                  string
 		constraint               string
-		availableVersionsFetcher func(url string) ([]string, error)
+		availableVersionsFetcher func(ctx context.Context, url string) ([]string, error)
 		want                     string
 		wantErr                  require.ErrorAssertionFunc
 	}{
@@ -25,7 +26,7 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			},
 			version: "latest",
 			want:    "2.0.0",
-			availableVersionsFetcher: func(url string) ([]string, error) {
+			availableVersionsFetcher: func(_ context.Context, url string) ([]string, error) {
 				return []string{"1.0.0", "2.0.0", "1.1.0"}, nil
 			},
 		},
@@ -52,7 +53,7 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			},
 			version: "latest",
 			wantErr: require.Error,
-			availableVersionsFetcher: func(url string) ([]string, error) {
+			availableVersionsFetcher: func(_ context.Context, url string) ([]string, error) {
 				return []string{""}, nil
 			},
 		},
@@ -64,7 +65,7 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			},
 			version: "latest",
 			want:    "latest", // this is a pass through to go-install, which supports this as input
-			availableVersionsFetcher: func(url string) ([]string, error) {
+			availableVersionsFetcher: func(_ context.Context, url string) ([]string, error) {
 				return nil, fmt.Errorf("should never be called")
 			},
 		},
@@ -77,7 +78,7 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			v := NewVersionResolver(tt.config)
 			v.availableVersionsFetcher = tt.availableVersionsFetcher
 
-			got, err := v.ResolveVersion(tt.version, tt.constraint)
+			got, err := v.ResolveVersion(context.Background(), tt.version, tt.constraint)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -90,7 +91,7 @@ func TestVersionResolver_UpdateVersion(t *testing.T) {
 		config                   VersionResolutionParameters
 		version                  string
 		constraint               string
-		availableVersionsFetcher func(url string) ([]string, error)
+		availableVersionsFetcher func(ctx context.Context, url string) ([]string, error)
 		want                     string
 		wantErr                  require.ErrorAssertionFunc
 	}{
@@ -109,7 +110,7 @@ func TestVersionResolver_UpdateVersion(t *testing.T) {
 			},
 			version: "1.0.0",
 			want:    "2.0.0",
-			availableVersionsFetcher: func(url string) ([]string, error) {
+			availableVersionsFetcher: func(_ context.Context, url string) ([]string, error) {
 				return []string{"1.0.0", "2.0.0", "1.1.0"}, nil
 			},
 		},
@@ -130,7 +131,7 @@ func TestVersionResolver_UpdateVersion(t *testing.T) {
 			v := NewVersionResolver(tt.config)
 			v.availableVersionsFetcher = tt.availableVersionsFetcher
 
-			got, err := v.UpdateVersion(tt.version, tt.constraint)
+			got, err := v.UpdateVersion(context.Background(), tt.version, tt.constraint)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/tool/hostedshell/installer.go
+++ b/tool/hostedshell/installer.go
@@ -2,6 +2,7 @@ package hostedshell
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -37,15 +38,15 @@ func NewInstaller(cfg InstallerParameters) Installer {
 	}
 }
 
-func (i Installer) InstallTo(version, destDir string) (string, error) {
-	lgr := log.Nested("tool", fmt.Sprintf("%s@%s", i.config.URL, version))
+func (i Installer) InstallTo(ctx context.Context, version, destDir string) (string, error) {
+	ctx, lgr := log.WithNested(ctx, "tool", fmt.Sprintf("%s@%s", i.config.URL, version))
 
 	lgr.Debug("installing from hosted shell script")
 
 	const scriptName = "install.sh"
 
 	scriptPath := filepath.Join(destDir, scriptName)
-	if err := internal.DownloadFile(lgr, i.config.URL, scriptPath, ""); err != nil {
+	if err := internal.DownloadFile(ctx, i.config.URL, scriptPath, ""); err != nil {
 		return "", fmt.Errorf("failed to download script: %v", err)
 	}
 

--- a/tool/hostedshell/installer_test.go
+++ b/tool/hostedshell/installer_test.go
@@ -1,6 +1,7 @@
 package hostedshell
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -71,7 +72,7 @@ func TestInstaller_InstallTo(t *testing.T) {
 			i := NewInstaller(tt.fields.config)
 			i.scriptRunner = tt.fields.scriptRunner
 			want := filepath.Join(tt.args.destDir, "syft")
-			got, err := i.InstallTo(tt.args.version, tt.args.destDir)
+			got, err := i.InstallTo(context.Background(), tt.args.version, tt.args.destDir)
 			if !tt.wantErr(t, err, fmt.Sprintf("InstallTo(%v, %v)", tt.args.version, tt.args.destDir)) {
 				return
 			}

--- a/tool/install.go
+++ b/tool/install.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -18,7 +19,7 @@ import (
 
 var ErrAlreadyInstalled = errors.New("already installed")
 
-func Install(tool binny.Tool, intent binny.VersionIntent, store *binny.Store, verifyConfig VerifyConfig) (err error) {
+func Install(ctx context.Context, tool binny.Tool, intent binny.VersionIntent, store *binny.Store, verifyConfig VerifyConfig) (err error) {
 	prog, stage := trackInstallation(tool.Name(), intent.Want)
 	defer func() {
 		if err != nil && !errors.Is(err, ErrAlreadyInstalled) {
@@ -38,7 +39,7 @@ func Install(tool binny.Tool, intent binny.VersionIntent, store *binny.Store, ve
 
 	stage.Set("resolving version")
 
-	resolvedVersion, err := tool.ResolveVersion(intent.Want, intent.Constraint)
+	resolvedVersion, err := tool.ResolveVersion(ctx, intent.Want, intent.Constraint)
 	if err != nil {
 		return fmt.Errorf("failed to resolve version for tool %q: %w", tool.Name(), err)
 	}
@@ -60,7 +61,7 @@ func Install(tool binny.Tool, intent binny.VersionIntent, store *binny.Store, ve
 	stage.Set(fmt.Sprintf("installing %q", resolvedVersion))
 
 	// install the tool to a temp dir
-	binPath, err := tool.InstallTo(resolvedVersion, tmpdir)
+	binPath, err := tool.InstallTo(ctx, resolvedVersion, tmpdir)
 	if err != nil {
 		return err
 	}

--- a/tool/resolve_version.go
+++ b/tool/resolve_version.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
@@ -19,13 +20,13 @@ func VersionResolverMethods() []string {
 	}
 }
 
-func ResolveVersion(tool binny.VersionResolver, intent binny.VersionIntent) (string, error) {
+func ResolveVersion(ctx context.Context, tool binny.VersionResolver, intent binny.VersionIntent) (string, error) {
 	want := intent.Want
 	constraint := intent.Constraint
 
 	var resolvedVersion string
 
-	resolvedVersion, err := tool.ResolveVersion(want, constraint)
+	resolvedVersion, err := tool.ResolveVersion(ctx, want, constraint)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve version: %w", err)
 	}


### PR DESCRIPTION
This makes a few changes:
- passes context through more places (especially where there are http calls)
- passes loggers through context, not as an argument
- passes the retryable http client through context, does not use static methods
- adds an adapter logging implementation for retryable http client

