### PR TITLE
docs: add note about default tool installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Then you can run:
   - `binny update [name...]` to update any pinned versions in the configuration with the latest available versions (and within any given constraints)
   - `binny list` to list all tools in the configuration and the installed store
 
+By default, tools are installed in a `.tool` directory in the current working directory. This can be configured via the `store.root` option (e.g., to use `~/.tool` for a user-wide install).
+
 Use `--ignore-cooldown` with `install` or `update` to bypass the release cooldown check.
 
 You can add tools to the configuration one of two ways:


### PR DESCRIPTION
Add a note in the Usage section explaining that tools are installed in a .tool directory by default (in the current working directory), and that this can be configured via the store.root option (e.g., to use ~/.tool for a user-wide install).

Fixes #112