### PR TITLE
chore(deps): restore Go version to 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/binny
 
-go 1.26.2
+go 1.24.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Restores the go directive in go.mod to 1.24.2 (pre-#267). Bumped in #267 (merge 7d12457bbe2283bec1d24758fc98e90b99667b0a).