### PR TITLE
Stop tripping GitHub's secondary rate limit on `binny update`

### DIFF
--- a/tool/githubrelease/retry_test.go
+++ b/tool/githubrelease/retry_test.go
@@ -39,3 +39,24 @@ func TestNewRetryableGitHubClient_RetriesWithAuthHeader(t *testing.T) {
 		assert.Equal(t, expectedAuth, auth, "request %d missing auth header", i+1)
 	}
 }
+
+func TestNewRetryableGitHubClient_DoesNotRetry403(t *testing.T) {
+	// 403 from GitHub is either auth failure or a secondary rate limit; neither
+	// resolves by retrying. Failing fast avoids the ~30s of backoff we used to
+	// burn on doomed requests for high-volume repos like cosign and golangci-lint.
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client := newRetryableGitHubClient(context.Background(), "test-token")
+
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 1, requests, "expected exactly 1 request (no retries on 403)")
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}

--- a/tool/githubrelease/retry_test.go
+++ b/tool/githubrelease/retry_test.go
@@ -2,6 +2,7 @@ package githubrelease
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -40,23 +41,37 @@ func TestNewRetryableGitHubClient_RetriesWithAuthHeader(t *testing.T) {
 	}
 }
 
-func TestNewRetryableGitHubClient_DoesNotRetry403(t *testing.T) {
-	// 403 from GitHub is either auth failure or a secondary rate limit; neither
-	// resolves by retrying. Failing fast avoids the ~30s of backoff we used to
-	// burn on doomed requests for high-volume repos like cosign and golangci-lint.
-	var requests int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requests++
-		w.WriteHeader(http.StatusForbidden)
-	}))
-	defer server.Close()
+func TestGithubRetryPolicy(t *testing.T) {
+	// the policy is forward-compat insurance: the current default already declines 403,
+	// but pinning it explicitly protects against an upstream change reintroducing
+	// wasted backoff on auth failures / secondary rate limits.
+	tests := []struct {
+		name       string
+		statusCode int
+		err        error
+		wantRetry  bool
+	}{
+		{name: "200 OK is not retried", statusCode: http.StatusOK, wantRetry: false},
+		{name: "403 Forbidden is not retried (pinned)", statusCode: http.StatusForbidden, wantRetry: false},
+		{name: "404 Not Found is not retried", statusCode: http.StatusNotFound, wantRetry: false},
+		{name: "429 Too Many Requests is retried", statusCode: http.StatusTooManyRequests, wantRetry: true},
+		{name: "500 Internal Server Error is retried", statusCode: http.StatusInternalServerError, wantRetry: true},
+		{name: "502 Bad Gateway is retried", statusCode: http.StatusBadGateway, wantRetry: true},
+		{name: "503 Service Unavailable is retried", statusCode: http.StatusServiceUnavailable, wantRetry: true},
+		{name: "504 Gateway Timeout is retried", statusCode: http.StatusGatewayTimeout, wantRetry: true},
+	}
 
-	client := newRetryableGitHubClient(context.Background(), "test-token")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{StatusCode: tt.statusCode}
+			gotRetry, err := githubRetryPolicy(context.Background(), resp, tt.err)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRetry, gotRetry)
+		})
+	}
 
-	resp, err := client.Get(server.URL)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, 1, requests, "expected exactly 1 request (no retries on 403)")
-	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	t.Run("transport error is retried (delegates to default policy)", func(t *testing.T) {
+		gotRetry, _ := githubRetryPolicy(context.Background(), nil, errors.New("connection refused"))
+		assert.True(t, gotRetry)
+	})
 }

--- a/tool/githubrelease/version_resolver.go
+++ b/tool/githubrelease/version_resolver.go
@@ -280,10 +280,38 @@ func newRetryableGitHubClient(ctx context.Context, token string) *http.Client {
 	retryClient.HTTPClient.Transport = oauth2Client.Transport
 	retryClient.Logger = nil
 
+	// keep retries short-lived: the original 1->30s backoff over 5 attempts could waste
+	// 30+ seconds on a request that's never going to succeed (e.g. GitHub secondary rate
+	// limits return 403, which are not retried, but transport-level errors during such
+	// rate-limit windows still trigger retries with the default policy).
+	retryClient.RetryMax = 3
+	retryClient.RetryWaitMax = 4 * time.Second
+	retryClient.CheckRetry = githubRetryPolicy
+
 	return retryClient.StandardClient()
 }
 
-//nolint:funlen
+// githubRetryPolicy wraps the default policy but explicitly never retries 403.
+// GitHub returns 403 for both authentication failures and secondary rate limits;
+// neither resolves by retrying the same request in a tight loop. Failing fast
+// surfaces the actual error to the user instead of burning ~30 seconds of backoff.
+func githubRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	if resp != nil && resp.StatusCode == http.StatusForbidden {
+		return false, nil
+	}
+	return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+}
+
+// graphql node budget per request. Larger pages bunch up against GitHub's secondary
+// rate limit (point-cost / node-limit) for high-volume repos. Multiple smaller pages
+// stay safely under the per-query threshold.
+const releasesPerPage = 25
+
+// total ceiling on releases fetched. Matches the original (un-paginated) behavior of
+// `first:100`, but spread across cheaper pages. Plenty to find the latest version
+// satisfying a constraint or cooldown.
+const maxReleasesFetched = 100
+
 func fetchAllReleasesFromGithubV4API(ctx context.Context, user, repo string) ([]ghRelease, error) {
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
@@ -291,106 +319,57 @@ func fetchAllReleasesFromGithubV4API(ctx context.Context, user, repo string) ([]
 	}
 
 	client := githubv4.NewClient(newRetryableGitHubClient(ctx, token))
+
+	// release assets are intentionally omitted from this query — they're not used for
+	// version resolution and pulling them inflates the GraphQL node count by ~100x per
+	// release, which trips GitHub's secondary rate limit (403) for high-volume repos.
+	// The installer fetches assets separately for the chosen release.
+	var query struct {
+		Repository struct {
+			Releases struct {
+				PageInfo struct {
+					EndCursor   githubv4.String
+					HasNextPage bool
+				}
+				Nodes []struct {
+					TagName     githubv4.String
+					IsLatest    githubv4.Boolean
+					IsDraft     githubv4.Boolean
+					PublishedAt githubv4.DateTime
+				}
+			} `graphql:"releases(first:$releasesPerPage, after:$releasesCursor)"` // newest first
+		} `graphql:"repository(owner:$repositoryOwner, name:$repositoryName)"`
+	}
+	variables := map[string]any{
+		"repositoryOwner": githubv4.String(user),
+		"repositoryName":  githubv4.String(repo),
+		"releasesPerPage": githubv4.Int(releasesPerPage),
+		"releasesCursor":  (*githubv4.String)(nil), // null = first page
+	}
+
 	var allReleases []ghRelease
-
-	// Query some details about a repository, an ghIssue in it, and its comments.
-	{
-		// TODO: act on hitting a rate limit
-		type rateLimit struct {
-			Cost      githubv4.Int
-			Limit     githubv4.Int
-			Remaining githubv4.Int
-			ResetAt   githubv4.DateTime
-		}
-
-		var query struct {
-			Repository struct {
-				DatabaseID githubv4.Int
-				URL        githubv4.URI
-				Releases   struct {
-					PageInfo struct {
-						EndCursor   githubv4.String
-						HasNextPage bool
-					}
-					Edges []struct {
-						Node struct {
-							TagName       githubv4.String
-							IsLatest      githubv4.Boolean
-							IsDraft       githubv4.Boolean
-							PublishedAt   githubv4.DateTime
-							ReleaseAssets struct {
-								PageInfo struct {
-									EndCursor   githubv4.String
-									HasNextPage bool
-								}
-								Nodes []struct {
-									Name        githubv4.String
-									ContentType githubv4.String
-									DownloadURL githubv4.URI
-								}
-							} `graphql:"releaseAssets(first:100, after:$assetsCursor)"`
-						}
-					}
-				} `graphql:"releases(first:100, after:$releasesCursor)"` // note: first 100 releases, where newest releases are first
-			} `graphql:"repository(owner:$repositoryOwner, name:$repositoryName)"`
-
-			RateLimit rateLimit
-		}
-		variables := map[string]any{
-			"repositoryOwner": githubv4.String(user),
-			"repositoryName":  githubv4.String(repo),
-			"releasesCursor":  (*githubv4.String)(nil), // Null after argument to get first page.
-			"assetsCursor":    (*githubv4.String)(nil), // Null after argument to get first page.
-		}
-
-		// TODO: go to the next page :) (cosign was taking a while here so this needs investigation)
-		// var limit rateLimit
-		// for {
-		err := client.Query(ctx, &query, variables)
-		if err != nil {
+	for {
+		if err := client.Query(ctx, &query, variables); err != nil {
 			return nil, err
 		}
-		//  limit = query.RateLimit
 
-		for iE := range query.Repository.Releases.Edges {
-			var assets []ghAsset
-
-			iEdge := query.Repository.Releases.Edges[iE]
-
-			// for {
-			for _, a := range iEdge.Node.ReleaseAssets.Nodes {
-				//  support charset spec, e.g. "text/plain; charset=utf-8""
-				contentType := strings.Split(string(a.ContentType), ";")[0]
-
-				assets = append(assets, ghAsset{
-					Name:        string(a.Name),
-					ContentType: contentType,
-					URL:         a.DownloadURL.String(),
-				})
-			}
-
-			// 	if !iEdge.Node.ReleaseAssets.PageInfo.HasNextPage {
-			// 		break
-			// 	}
-			// 	variables["assetsCursor"] = githubv4.NewString(iEdge.Node.ReleaseAssets.PageInfo.EndCursor)
-			// }
-
+		for _, node := range query.Repository.Releases.Nodes {
+			publishedAt := node.PublishedAt.Time
 			allReleases = append(allReleases, ghRelease{
-				Tag:      string(iEdge.Node.TagName),
-				IsLatest: boolRef(bool(iEdge.Node.IsLatest)),
-				IsDraft:  boolRef(bool(iEdge.Node.IsDraft)),
-				Date:     &iEdge.Node.PublishedAt.Time,
-				Assets:   assets,
+				Tag:      string(node.TagName),
+				IsLatest: boolRef(bool(node.IsLatest)),
+				IsDraft:  boolRef(bool(node.IsDraft)),
+				Date:     &publishedAt,
 			})
 		}
 
-		//	if !query.Repository.Releases.PageInfo.HasNextPage {
-		//		break
-		//	}
-		//	variables["releasesCursor"] = githubv4.NewString(query.Repository.Releases.PageInfo.EndCursor)
-		//}
-
-		// printJSON(allReleases)
+		if !query.Repository.Releases.PageInfo.HasNextPage {
+			break
+		}
+		if len(allReleases) >= maxReleasesFetched {
+			break
+		}
+		variables["releasesCursor"] = githubv4.NewString(query.Repository.Releases.PageInfo.EndCursor)
 	}
 
 	sort.Slice(allReleases, func(i, j int) bool {

--- a/tool/githubrelease/version_resolver.go
+++ b/tool/githubrelease/version_resolver.go
@@ -280,10 +280,10 @@ func newRetryableGitHubClient(ctx context.Context, token string) *http.Client {
 	retryClient.HTTPClient.Transport = oauth2Client.Transport
 	retryClient.Logger = nil
 
-	// keep retries short-lived: the original 1->30s backoff over 5 attempts could waste
-	// 30+ seconds on a request that's never going to succeed (e.g. GitHub secondary rate
-	// limits return 403, which are not retried, but transport-level errors during such
-	// rate-limit windows still trigger retries with the default policy).
+	// keep retries short-lived: the default 1->30s backoff over 5 attempts could waste
+	// 30+ seconds on a request that's never going to succeed (e.g. transport-level errors
+	// during a GitHub secondary rate-limit window). Capping at 3 retries with a 4s ceiling
+	// bounds the worst case to roughly 8s before surfacing the failure to the user.
 	retryClient.RetryMax = 3
 	retryClient.RetryWaitMax = 4 * time.Second
 	retryClient.CheckRetry = githubRetryPolicy
@@ -291,10 +291,11 @@ func newRetryableGitHubClient(ctx context.Context, token string) *http.Client {
 	return retryClient.StandardClient()
 }
 
-// githubRetryPolicy wraps the default policy but explicitly never retries 403.
-// GitHub returns 403 for both authentication failures and secondary rate limits;
-// neither resolves by retrying the same request in a tight loop. Failing fast
-// surfaces the actual error to the user instead of burning ~30 seconds of backoff.
+// githubRetryPolicy wraps the default policy and pins "never retry 403" explicitly.
+// GitHub returns 403 for both auth failures and secondary rate limits; neither resolves
+// by retrying. The current default policy already declines 403 (it only retries 429 and
+// 5xx), so this is forward-compat insurance: an upstream change can't reintroduce the
+// wasted backoff window.
 func githubRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
 	if resp != nil && resp.StatusCode == http.StatusForbidden {
 		return false, nil
@@ -307,9 +308,13 @@ func githubRetryPolicy(ctx context.Context, resp *http.Response, err error) (boo
 // stay safely under the per-query threshold.
 const releasesPerPage = 25
 
-// total ceiling on releases fetched. Matches the original (un-paginated) behavior of
+// soft ceiling on releases fetched. Matches the original (un-paginated) behavior of
 // `first:100`, but spread across cheaper pages. Plenty to find the latest version
-// satisfying a constraint or cooldown.
+// satisfying a constraint or cooldown for any reasonable repo. Note: this cap is
+// approximate — the loop checks after appending a full page, so the realized cap is
+// up to maxReleasesFetched + releasesPerPage - 1. Also note: a constraint that only
+// matches releases beyond this cap will silently fail to find a match (caller will
+// see "no latest version found"). Same trade-off as the original `first:100`.
 const maxReleasesFetched = 100
 
 func fetchAllReleasesFromGithubV4API(ctx context.Context, user, repo string) ([]ghRelease, error) {


### PR DESCRIPTION
`binny update` was reliably hitting GitHub 403s on high-volume repos (cosign, golangci-lint), and each failure took ~60s to surface. 

Root cause: the releases-list GraphQL query asked for **100 releases × 100 assets each** (~10k nodes), which trips GitHub's per-query secondary rate limit. The assets data wasn't even used... `filterToLatestVersion` only reads tag/date/flags, and the installer fetches assets separately. There's a pre-existing TODO at `version_resolver.go:346` calling this out.

Changes:

- **Drop assets from the version-resolution query.** Just `tagName`, `isLatest`, `isDraft`, `publishedAt` now. Per-page node count drops ~100×.
- **Real pagination.** `first:25`, paginated up to ~100 total releases (was `first:100` single-shot). Same coverage, no single request can balloon. Cap is approximate — the loop checks after appending a full page, so realized total is up to `maxReleasesFetched + releasesPerPage - 1`. A constraint that only matches releases beyond the cap will silently fail to find a match (same trade-off as the original `first:100`).
- **Tighten retries.** `RetryMax` changed from 4 to 3, `RetryWaitMax` changed from 30s to 4s... worst-case backoff drops from ~31s to ~7s. This is where the actual perf win lives.
- **Custom retry policy as forward-compat insurance.** `githubRetryPolicy` explicitly declines 403. The current `retryablehttp` default policy already doesn't retry 403 (it only retries 429 and 5xx), so this is not the source of the speedup — it's a guard against an upstream change reintroducing wasted backoff on auth fails / secondary rate limits.
